### PR TITLE
Enable relative paths in configuration

### DIFF
--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -21,8 +21,12 @@ export class DotnetTestExplorer implements vscode.TreeDataProvider<vscode.TreeIt
 
         try {
             const testProjectPath = Utility.getConfiguration().get<string>("testProjectPath");
-            this.cwd = testProjectPath ? testProjectPath : vscode.workspace.rootPath;
-            const testStrings = Executor.execSync("dotnet test -t", this. cwd)
+            let testProjectFullPath = testProjectPath ? testProjectPath : vscode.workspace.rootPath;
+            if(!path.isAbsolute(testProjectFullPath)){
+                testProjectFullPath = path.resolve(vscode.workspace.rootPath, testProjectPath);
+            }
+            this.cwd  = testProjectFullPath;
+            const testStrings = Executor.execSync("dotnet test -t", this.cwd)
                 .split(/[\r\n]+/g).filter((item) => item);
             const index = testStrings.indexOf("The following Tests are available:");
             if (index > -1) {

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -22,7 +22,7 @@ export class DotnetTestExplorer implements vscode.TreeDataProvider<vscode.TreeIt
         try {
             const testProjectPath = Utility.getConfiguration().get<string>("testProjectPath");
             let testProjectFullPath = testProjectPath ? testProjectPath : vscode.workspace.rootPath;
-            if(!path.isAbsolute(testProjectFullPath)){
+            if (!path.isAbsolute(testProjectFullPath)) {
                 testProjectFullPath = path.resolve(vscode.workspace.rootPath, testProjectPath);
             }
             this.cwd  = testProjectFullPath;


### PR DESCRIPTION
I added a possibility to use a relative path to test project instead of full path. This option is more team friendly.