### PR TITLE
Allow to specify searched text in MsBuld output

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
           "type": "string",
           "default": "",
           "description": "Folder path of .NET Core test project."
+        },
+        "dotnet-test-explorer.msbuildRootTestMsg": {
+          "type": "string",
+          "default": "",
+          "description": "A root message for dotnet test command. In English it is 'The following Tests are available:' but for example in Polish it is 'Dostępne są następujące testy:'"
         }
       }
     }

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -24,7 +24,9 @@ export class DotnetTestExplorer implements vscode.TreeDataProvider<vscode.TreeIt
             this.cwd = testProjectPath ? testProjectPath : vscode.workspace.rootPath;
             const testStrings = Executor.execSync("dotnet test -t", this. cwd)
                 .split(/[\r\n]+/g).filter((item) => item);
-            const index = testStrings.indexOf("The following Tests are available:");
+            let msBuildRootTestMsg = Utility.getConfiguration().get<string>("msbuildRootTestMsg");
+            msBuildRootTestMsg = msBuildRootTestMsg ? msBuildRootTestMsg : "The following Tests are available:";
+            const index = testStrings.indexOf(msBuildRootTestMsg);
             if (index > -1) {
                 tests = testStrings.slice(index + 1).map((item) => {
                     const test = new vscode.TreeItem(item.trim());


### PR DESCRIPTION
If a user (like me) has an MSBuild outputs in the other language than English the extension cannot find any tests. This PR allows overriding the default search message in the MSBuild output to the localized one.