### PR TITLE
Created option to display tests in a tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         },
         "dotnet-test-explorer.useTreeView": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "If false, will list all tests as the full namespace. When set to true a tree will be created based on the namespaces of the tests."
         }
       }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
           "type": "string",
           "default": "",
           "description": "A root message for dotnet test command. In English it is 'The following Tests are available:' but for example in Polish it is 'Dostępne są następujące testy:'"
+        },
+        "dotnet-test-explorer.useTreeView": {
+          "type": "boolean",
+          "default": false,
+          "description": "If false, will list all tests as the full namespace. When set to true a tree will be created based on the namespaces of the tests."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "dotnet-test-explorer.useTreeView": {
           "type": "boolean",
           "default": true,
-          "description": "If false, will list all tests as the full namespace. When set to true a tree will be created based on the namespaces of the tests."
+          "description": "If false, will list all tests as the full namespace. When set to true a tree will be created based on the namespaces of the tests. (Only xUnit tests will be listed in a tree view)"
         }
       }
     }

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -3,44 +3,151 @@ import * as vscode from "vscode";
 import { AppInsightsClient } from "./appInsightsClient";
 import { Executor } from "./executor";
 import { Utility } from "./utility";
+import { TreeDataProvider, TreeItem, TreeItemCollapsibleState } from "vscode";
 
-export class DotnetTestExplorer implements vscode.TreeDataProvider<vscode.TreeItem> {
+export class TestNode {
+    private _isError: boolean;
+
+    constructor(private _parentPath: string, private _name: string, private _children?: TestNode[]) {
+    }
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public get fullName(): String {
+        return `${this._parentPath}.${this._name}`;
+    };
+
+    public get isFolder(): boolean {
+        return this._children && this._children.length > 0;
+    }
+
+    public get children(): TestNode[] {
+        return this._children;
+    }
+
+    public get isError(): boolean {
+        return !!this._isError;
+    }
+
+    public setAsError(error: string) {
+        this._isError = true;
+        this._name = error;
+    }
+}
+
+export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
     public _onDidChangeTreeData: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
     public readonly onDidChangeTreeData: vscode.Event<any> = this._onDidChangeTreeData.event;
-    private cwd;
+
+    private testDirectoryPath: string;
 
     constructor(private context: vscode.ExtensionContext) {
     }
 
-    public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
-        return element;
-    }
-
-    public getChildren(element?: vscode.TreeItem): Thenable<vscode.TreeItem[]> {
-        let tests = [];
-
-        try {
-            this.evaluateWorkingDirectory();
-            const testStrings = Executor.execSync("dotnet test -t", this.cwd)
-                .split(/[\r\n]+/g).filter((item) => item && !item.startsWith("[xUnit.net"));
-            let msBuildRootTestMsg = Utility.getConfiguration().get<string>("msbuildRootTestMsg");
-            msBuildRootTestMsg = msBuildRootTestMsg ? msBuildRootTestMsg : "The following Tests are available:";
-            const index = testStrings.indexOf(msBuildRootTestMsg);
-            if (index > -1) {
-                tests = testStrings.slice(index + 1).map((item) => {
-                    const test = new vscode.TreeItem(item.trim());
-                    test.iconPath = {
-                        dark: this.context.asAbsolutePath(path.join("resources", "dark", "run.png")),
-                        light: this.context.asAbsolutePath(path.join("resources", "light", "run.png")),
-                    };
-                    return test;
-                });
-            }
-        } catch (error) {
-            tests = [new vscode.TreeItem("Please open or set the test project")];
+    public getTreeItem(element: TestNode): TreeItem {
+        if(element.isError) {
+            return new TreeItem(element.name);
         }
 
-        return Promise.resolve(tests);
+        return {
+            label: element.name,
+            collapsibleState: element.isFolder ? TreeItemCollapsibleState.Collapsed : void 0,
+            iconPath: {
+                dark: this.context.asAbsolutePath(path.join("resources", "dark", "run.png")),
+                light: this.context.asAbsolutePath(path.join("resources", "light", "run.png")),
+            }
+        };
+    }
+
+    private addToObject(container: Object, parts: string[]): void {
+        const title = parts.splice(0, 1)[0];
+
+        if(parts.length == 1) {
+            if(!container[title]) container[title] = [];
+            container[title].push(parts[0]);
+            return;
+        }
+
+        if(!container[title]) container[title] = {};
+        this.addToObject(container[title], parts);
+    }
+
+    private createTestNode(parentPath: string, test: Object | string): TestNode[] {
+        if(Array.isArray(test)) {
+            return test.map(t => {
+                return new TestNode(parentPath, t);
+            });
+        }
+        else if(typeof test === 'object') {
+            return Object.keys(test).map(key => {
+                return new TestNode(parentPath, key, this.createTestNode((parentPath ? `${parentPath}.` : '') + key, test[key]));
+            });
+        }
+        else {
+            return [new TestNode(parentPath, test)];
+        }
+    }
+
+    public getChildren(element?: TestNode): TestNode[] | Thenable<TestNode[]> {
+        if(element) return element.children;
+
+        const useTreeView = Utility.getConfiguration().get<string>("useTreeView");
+
+        return this.loadTestStrings().then((fullNames: string[]) => {
+            if(!useTreeView) {
+                return fullNames.map(name => {
+                    return new TestNode('', name);
+                });
+            }
+
+            let structuredTests = {};
+
+            fullNames.forEach((name: string) => {
+                let parts = name.trim().split(".");
+                this.addToObject(structuredTests, parts);
+            });
+
+            let root = this.createTestNode('', structuredTests);
+            return root;
+        }, (reason: any) => {
+            return reason.map(e => {
+                let item = new TestNode("", null);
+                item.setAsError(e);
+                return item;
+            });
+        });
+    }
+
+    private loadTestStrings(): Thenable<string[]> {
+        this.evaluateTestDirectory();
+
+        let msBuildRootTestMsg = Utility.getConfiguration().get<string>("msbuildRootTestMsg");
+        msBuildRootTestMsg = msBuildRootTestMsg ? msBuildRootTestMsg : "The following Tests are available:";
+
+        return new Promise((c, e) => {
+            try {
+                const testStrings = Executor
+                    .execSync("dotnet test -t", this.testDirectoryPath)
+                    .split(/[\r\n]+/g)
+                    .filter((item) => item && !item.startsWith("[xUnit.net"));
+
+                const index = testStrings.indexOf(msBuildRootTestMsg);
+                if (index > -1) {
+                    const result = testStrings
+                        .slice(index + 1)
+                        .sort((a, b) => a > b ? 1 : b > a ? -1 : 0)
+
+                    c(result);
+                }
+            }
+            catch (error) {
+                return e(["Please open or set the test project", "and ensure your project compiles."]);
+            }
+
+            return c([]);
+        });
     }
 
     public refreshTestExplorer(): void {
@@ -49,22 +156,22 @@ export class DotnetTestExplorer implements vscode.TreeDataProvider<vscode.TreeIt
     }
 
     public runAllTests(): void {
-        this.evaluateWorkingDirectory();
-        Executor.runInTerminal("dotnet test", this.cwd);
+        this.evaluateTestDirectory();
+        Executor.runInTerminal("dotnet test", this.testDirectoryPath);
         AppInsightsClient.sendEvent("runAllTests");
     }
 
-    public runTest(methodName: string): void {
-        Executor.runInTerminal(`dotnet test --filter FullyQualifiedName~${methodName}`, this.cwd);
+    public runTest(test: TestNode): void {
+        Executor.runInTerminal(`dotnet test --filter FullyQualifiedName~${test.fullName}`, this.testDirectoryPath);
         AppInsightsClient.sendEvent("runTest");
     }
 
-    private evaluateWorkingDirectory(): void {
+    private evaluateTestDirectory(): void {
         const testProjectPath = Utility.getConfiguration().get<string>("testProjectPath");
         let testProjectFullPath = testProjectPath ? testProjectPath : vscode.workspace.rootPath;
         if (!path.isAbsolute(testProjectFullPath)) {
             testProjectFullPath = path.resolve(vscode.workspace.rootPath, testProjectPath);
         }
-        this.cwd = testProjectFullPath;
+        this.testDirectoryPath = testProjectFullPath;
     }
 }

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -47,7 +47,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
             const structuredTests = {};
 
             fullNames.forEach((name: string) => {
-                const parts = name.trim().split(".");
+                const parts = name.split(".");
                 this.addToObject(structuredTests, parts);
             });
 
@@ -81,18 +81,20 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
     private addToObject(container: object, parts: string[]): void {
         const title = parts.splice(0, 1)[0];
 
-        if (parts.length === 1) {
+        if (parts.length > 1) {
+            if (!container[title]) {
+                container[title] = {};
+            }
+            this.addToObject(container[title], parts);
+        } else {
             if (!container[title]) {
                 container[title] = [];
             }
-            container[title].push(parts[0]);
-            return;
-        }
 
-        if (!container[title]) {
-            container[title] = {};
+            if (parts.length === 1) {
+                container[title].push(parts[0]);
+            }
         }
-        this.addToObject(container[title], parts);
     }
 
     private createTestNode(parentPath: string, test: object | string): TestNode[] {
@@ -120,7 +122,8 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
                 const testStrings = Executor
                     .execSync("dotnet test -t", this.testDirectoryPath)
                     .split(/[\r\n]+/g)
-                    .filter((item) => item && !item.startsWith("[xUnit.net"));
+                    .filter((item) => item && !item.startsWith("[xUnit.net"))
+                    .map((item) => item.trim());
 
                 const index = testStrings.indexOf(msBuildRootTestMsg);
                 if (index > -1) {

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -1,41 +1,10 @@
 import * as path from "path";
 import * as vscode from "vscode";
+import { TreeDataProvider, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { AppInsightsClient } from "./appInsightsClient";
 import { Executor } from "./executor";
+import { TestNode } from "./testNode";
 import { Utility } from "./utility";
-import { TreeDataProvider, TreeItem, TreeItemCollapsibleState } from "vscode";
-
-export class TestNode {
-    private _isError: boolean;
-
-    constructor(private _parentPath: string, private _name: string, private _children?: TestNode[]) {
-    }
-
-    public get name(): string {
-        return this._name;
-    }
-
-    public get fullName(): String {
-        return `${this._parentPath}.${this._name}`;
-    };
-
-    public get isFolder(): boolean {
-        return this._children && this._children.length > 0;
-    }
-
-    public get children(): TestNode[] {
-        return this._children;
-    }
-
-    public get isError(): boolean {
-        return !!this._isError;
-    }
-
-    public setAsError(error: string) {
-        this._isError = true;
-        this._name = error;
-    }
-}
 
 export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
     public _onDidChangeTreeData: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
@@ -47,7 +16,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
     }
 
     public getTreeItem(element: TestNode): TreeItem {
-        if(element.isError) {
+        if (element.isError) {
             return new TreeItem(element.name);
         }
 
@@ -57,67 +26,87 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
             iconPath: {
                 dark: this.context.asAbsolutePath(path.join("resources", "dark", "run.png")),
                 light: this.context.asAbsolutePath(path.join("resources", "light", "run.png")),
-            }
+            },
         };
     }
 
-    private addToObject(container: Object, parts: string[]): void {
-        const title = parts.splice(0, 1)[0];
-
-        if(parts.length == 1) {
-            if(!container[title]) container[title] = [];
-            container[title].push(parts[0]);
-            return;
-        }
-
-        if(!container[title]) container[title] = {};
-        this.addToObject(container[title], parts);
-    }
-
-    private createTestNode(parentPath: string, test: Object | string): TestNode[] {
-        if(Array.isArray(test)) {
-            return test.map(t => {
-                return new TestNode(parentPath, t);
-            });
-        }
-        else if(typeof test === 'object') {
-            return Object.keys(test).map(key => {
-                return new TestNode(parentPath, key, this.createTestNode((parentPath ? `${parentPath}.` : '') + key, test[key]));
-            });
-        }
-        else {
-            return [new TestNode(parentPath, test)];
-        }
-    }
-
     public getChildren(element?: TestNode): TestNode[] | Thenable<TestNode[]> {
-        if(element) return element.children;
+        if (element) {
+            return element.children;
+        }
 
         const useTreeView = Utility.getConfiguration().get<string>("useTreeView");
 
         return this.loadTestStrings().then((fullNames: string[]) => {
-            if(!useTreeView) {
-                return fullNames.map(name => {
-                    return new TestNode('', name);
+            if (!useTreeView) {
+                return fullNames.map((name) => {
+                    return new TestNode("", name);
                 });
             }
 
-            let structuredTests = {};
+            const structuredTests = {};
 
             fullNames.forEach((name: string) => {
-                let parts = name.trim().split(".");
+                const parts = name.trim().split(".");
                 this.addToObject(structuredTests, parts);
             });
 
-            let root = this.createTestNode('', structuredTests);
+            const root = this.createTestNode("", structuredTests);
             return root;
         }, (reason: any) => {
-            return reason.map(e => {
-                let item = new TestNode("", null);
+            return reason.map((e) => {
+                const item = new TestNode("", null);
                 item.setAsError(e);
                 return item;
             });
         });
+    }
+
+    public refreshTestExplorer(): void {
+        this._onDidChangeTreeData.fire();
+        AppInsightsClient.sendEvent("refreshTestExplorer");
+    }
+
+    public runAllTests(): void {
+        this.evaluateTestDirectory();
+        Executor.runInTerminal("dotnet test", this.testDirectoryPath);
+        AppInsightsClient.sendEvent("runAllTests");
+    }
+
+    public runTest(test: TestNode): void {
+        Executor.runInTerminal(`dotnet test --filter FullyQualifiedName~${test.fullName}`, this.testDirectoryPath);
+        AppInsightsClient.sendEvent("runTest");
+    }
+
+    private addToObject(container: object, parts: string[]): void {
+        const title = parts.splice(0, 1)[0];
+
+        if (parts.length === 1) {
+            if (!container[title]) {
+                container[title] = [];
+            }
+            container[title].push(parts[0]);
+            return;
+        }
+
+        if (!container[title]) {
+            container[title] = {};
+        }
+        this.addToObject(container[title], parts);
+    }
+
+    private createTestNode(parentPath: string, test: object | string): TestNode[] {
+        if (Array.isArray(test)) {
+            return test.map((t) => {
+                return new TestNode(parentPath, t);
+            });
+        } else if (typeof test === "object") {
+            return Object.keys(test).map((key) => {
+                return new TestNode(parentPath, key, this.createTestNode((parentPath ? `${parentPath}.` : "") + key, test[key]));
+            });
+        } else {
+            return [new TestNode(parentPath, test)];
+        }
     }
 
     private loadTestStrings(): Thenable<string[]> {
@@ -137,33 +126,16 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
                 if (index > -1) {
                     const result = testStrings
                         .slice(index + 1)
-                        .sort((a, b) => a > b ? 1 : b > a ? -1 : 0)
+                        .sort((a, b) => a > b ? 1 : b > a ? -1 : 0);
 
                     c(result);
                 }
-            }
-            catch (error) {
+            } catch (error) {
                 return e(["Please open or set the test project", "and ensure your project compiles."]);
             }
 
             return c([]);
         });
-    }
-
-    public refreshTestExplorer(): void {
-        this._onDidChangeTreeData.fire();
-        AppInsightsClient.sendEvent("refreshTestExplorer");
-    }
-
-    public runAllTests(): void {
-        this.evaluateTestDirectory();
-        Executor.runInTerminal("dotnet test", this.testDirectoryPath);
-        AppInsightsClient.sendEvent("runAllTests");
-    }
-
-    public runTest(test: TestNode): void {
-        Executor.runInTerminal(`dotnet test --filter FullyQualifiedName~${test.fullName}`, this.testDirectoryPath);
-        AppInsightsClient.sendEvent("runTest");
     }
 
     private evaluateTestDirectory(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from "vscode";
 import { AppInsightsClient } from "./appInsightsClient";
-import { DotnetTestExplorer } from "./dotnetTestExplorer";
+import { DotnetTestExplorer, TestNode } from "./dotnetTestExplorer";
 import { Executor } from "./executor";
 
 export function activate(context: vscode.ExtensionContext) {
@@ -18,8 +18,8 @@ export function activate(context: vscode.ExtensionContext) {
         dotnetTestExplorer.runAllTests();
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.runTest", (test) => {
-        dotnetTestExplorer.runTest(test.label);
+    context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.runTest", (test: TestNode) => {
+        dotnetTestExplorer.runTest(test);
     }));
 
     context.subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,9 @@
 
 import * as vscode from "vscode";
 import { AppInsightsClient } from "./appInsightsClient";
-import { DotnetTestExplorer, TestNode } from "./dotnetTestExplorer";
+import { DotnetTestExplorer } from "./dotnetTestExplorer";
 import { Executor } from "./executor";
+import { TestNode } from "./testNode";
 
 export function activate(context: vscode.ExtensionContext) {
     const dotnetTestExplorer = new DotnetTestExplorer(context);

--- a/src/testNode.ts
+++ b/src/testNode.ts
@@ -9,7 +9,7 @@ export class TestNode {
     }
 
     public get fullName(): string {
-        return `${this._parentPath}.${this._name}`;
+        return (this._parentPath ? `${this._parentPath}.` : "") + this._name;
     }
 
     public get isFolder(): boolean {

--- a/src/testNode.ts
+++ b/src/testNode.ts
@@ -1,0 +1,31 @@
+export class TestNode {
+    private _isError: boolean;
+
+    constructor(private _parentPath: string, private _name: string, private _children?: TestNode[]) {
+    }
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public get fullName(): string {
+        return `${this._parentPath}.${this._name}`;
+    }
+
+    public get isFolder(): boolean {
+        return this._children && this._children.length > 0;
+    }
+
+    public get children(): TestNode[] {
+        return this._children;
+    }
+
+    public get isError(): boolean {
+        return !!this._isError;
+    }
+
+    public setAsError(error: string) {
+        this._isError = true;
+        this._name = error;
+    }
+}


### PR DESCRIPTION
Fixes: #10 

After looking through the code, I noticed it wouldn't be too tough to just build a tree and return the nodes instead of simply returning the full namespaces. Did have to almost completely rewrite the test explorer class though.