### PR TITLE
Add support for test names that contain data

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,15 @@
   "main": "./out/src/extension",
   "contributes": {
     "views": {
-      "explorer": [{
-        "id": "dotnetTestExplorer",
-        "name": ".NET Test Explorer"
-      }]
+      "explorer": [
+        {
+          "id": "dotnetTestExplorer",
+          "name": ".NET Test Explorer"
+        }
+      ]
     },
-    "commands": [{
+    "commands": [
+      {
         "command": "dotnet-test-explorer.refreshTestExplorer",
         "title": "Refresh",
         "icon": {
@@ -61,7 +64,8 @@
       }
     ],
     "menus": {
-      "view/title": [{
+      "view/title": [
+        {
           "command": "dotnet-test-explorer.refreshTestExplorer",
           "when": "view == dotnetTestExplorer",
           "group": "navigation@1"
@@ -72,11 +76,13 @@
           "group": "navigation@0"
         }
       ],
-      "view/item/context": [{
-        "command": "dotnet-test-explorer.runTest",
-        "when": "view == dotnetTestExplorer",
-        "group": "dotnetTestExplorer@0"
-      }]
+      "view/item/context": [
+        {
+          "command": "dotnet-test-explorer.runTest",
+          "when": "view == dotnetTestExplorer",
+          "group": "dotnetTestExplorer@0"
+        }
+      ]
     },
     "configuration": {
       "type": "object",

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -89,8 +89,20 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
             const structuredTests = {};
 
             fullNames.forEach((name: string) => {
-                const parts = name.split(".");
-                this.addToObject(structuredTests, parts);
+                // this regex matches test names that include data in them - for e.g.
+                //  Foo.Bar.BazTest(p1=10, p2="blah.bleh")
+                const match = /([^\(]+)(.*)/g.exec(name);
+                if (match && match.length > 1) {
+                    const parts = match[1].split(".");
+                    if (match.length > 2 && match[2].trim().length > 0) {
+                        // append the data bit of the test to the test method name
+                        // so we can distinguish one test from another in the explorer
+                        // pane
+                        const testMethodName = parts[parts.length - 1];
+                        parts[parts.length - 1] = testMethodName + match[2];
+                    }
+                    this.addToObject(structuredTests, parts);
+                }
             });
 
             const root = this.createTestNode("", structuredTests);


### PR DESCRIPTION
In some cases test names include data in them. For e.g. when using xUnit you can create the so-called 'Theory' tests which run a given test with different inputs generated by a static method. In this case the test platform returns individual tests with different inputs. This commit fixes the parsing logic to allow for such tests to be included in the test explorer.