### PR TITLE
Display test results in CodeLens

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
-    "applicationinsights": "^0.21.0"
+    "applicationinsights": "^0.21.0",
+    "xmldom": "^0.1.27"
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,21 @@
           "type": "boolean",
           "default": true,
           "description": "Determines whether to show the CodeLens test status or not."
+        },
+        "dotnet-test-explorer.codeLensFailed": {
+          "type": "string",
+          "default": "",
+          "description": "The text to display in the code lens when a test has failed."
+        },
+        "dotnet-test-explorer.codeLensPassed": {
+          "type": "string",
+          "default": "",
+          "description": "The text to display in the code lens when a test has passed."
+        },
+        "dotnet-test-explorer.codeLensSkipped": {
+          "type": "string",
+          "default": "",
+          "description": "The text to display in the code lens when a test has been skipped."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,11 @@
           "type": "boolean",
           "default": true,
           "description": "If true, dotnet restore will run when refreshing the test explorer."
+        },
+        "dotnet-test-explorer.showCodeLens": {
+          "type": "boolean",
+          "default": true,
+          "description": "Determines whether to show the CodeLens test status or not."
         }
       }
     }

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -189,7 +189,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      * Gets the dotnet test argument to speicfy the output for the test results.
      */
     private outputTestResults(): string {
-        return " --logger 'trx;LogFileName=" + this.resultsFile.fileName + "'";
+        return " --logger \"trx;LogFileName=" + this.resultsFile.fileName + "\"";
     }
 
     /**

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -4,6 +4,7 @@ import { TreeDataProvider, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { AppInsightsClient } from "./appInsightsClient";
 import { Executor } from "./executor";
 import { TestNode } from "./testNode";
+import { TestResultsFile } from "./testResultsFile";
 import { Utility } from "./utility";
 
 export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
@@ -16,7 +17,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      */
     private testDirectoryPath: string;
 
-    constructor(private context: vscode.ExtensionContext) {}
+    constructor(private context: vscode.ExtensionContext, private resultsFile : TestResultsFile) { }
 
     /**
      * @description
@@ -41,7 +42,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      */
     public runAllTests(): void {
         this.evaluateTestDirectory();
-        Executor.runInTerminal(`dotnet test${this.checkBuildOption()}${this.checkRestoreOption()}`, this.testDirectoryPath);
+        Executor.runInTerminal(`dotnet test${this.getDotNetTestOptions()}${this.outputTestResults()}`, this.testDirectoryPath);
         AppInsightsClient.sendEvent("runAllTests");
     }
 
@@ -53,7 +54,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      * to do a restore, so it can be very slow.
      */
     public runTest(test: TestNode): void {
-        Executor.runInTerminal(`dotnet test${this.checkBuildOption()}${this.checkRestoreOption()} --filter FullyQualifiedName~${test.fullName}`, this.testDirectoryPath);
+        Executor.runInTerminal(`dotnet test${this.getDotNetTestOptions()}${this.outputTestResults()} --filter FullyQualifiedName~${test.fullName}`, this.testDirectoryPath);
         AppInsightsClient.sendEvent("runTest");
     }
 
@@ -177,6 +178,22 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
 
     /**
      * @description
+     * Gets the options for build/restore before running tests.
+     */
+    private getDotNetTestOptions(): string {
+        return this.checkBuildOption() + this.checkRestoreOption();
+    }
+
+    /**
+     * @description
+     * Gets the dotnet test argument to speicfy the output for the test results.
+     */
+    private outputTestResults(): string {
+        return " --logger 'trx;LogFileName=" + this.resultsFile.fileName + "'";
+    }
+
+    /**
+     * @description
      * Checks to see if the options specify a directory to run the
      * dotnet-cli test commands in.
      * @summary
@@ -198,7 +215,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
         return new Promise((c, e) => {
             try {
                 const results = Executor
-                    .execSync(`dotnet test -t -v=q${this.checkBuildOption()}${this.checkRestoreOption()}`, this.testDirectoryPath)
+                    .execSync(`dotnet test -t -v=q${this.getDotNetTestOptions()}`, this.testDirectoryPath)
                     .split(/[\r\n]+/g)
                     /*
                      * The dotnet-cli prefixes all discovered unit tests
@@ -207,7 +224,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
                      * structures.
                      **/
                     .filter((item) => item && item.startsWith("  "))
-                    .sort((a, b) => a > b ? 1 : b > a ? - 1 : 0 )
+                    .sort((a, b) => a > b ? 1 : b > a ? - 1 : 0)
                     .map((item) => item.trim());
 
                 c(results);

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -189,7 +189,11 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      * Gets the dotnet test argument to speicfy the output for the test results.
      */
     private outputTestResults(): string {
-        return " --logger \"trx;LogFileName=" + this.resultsFile.fileName + "\"";
+        if (Utility.codeLensEnabled()) {
+            return " --logger \"trx;LogFileName=" + this.resultsFile.fileName + "\"";
+        } else {
+            return "";
+        }
     }
 
     /**

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -189,7 +189,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      * Gets the dotnet test argument to speicfy the output for the test results.
      */
     private outputTestResults(): string {
-        if (Utility.codeLensEnabled()) {
+        if (Utility.codeLensEnabled) {
             return " --logger \"trx;LogFileName=" + this.resultsFile.fileName + "\"";
         } else {
             return "";

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -17,7 +17,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
      */
     private testDirectoryPath: string;
 
-    constructor(private context: vscode.ExtensionContext, private resultsFile : TestResultsFile) { }
+    constructor(private context: vscode.ExtensionContext, private resultsFile: TestResultsFile) { }
 
     /**
      * @description

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,9 +5,14 @@ import { AppInsightsClient } from "./appInsightsClient";
 import { DotnetTestExplorer } from "./dotnetTestExplorer";
 import { Executor } from "./executor";
 import { TestNode } from "./testNode";
+import { TestResultsFile } from "./testResultsFile";
+import { Utility } from "./utility";
 
 export function activate(context: vscode.ExtensionContext) {
-    const dotnetTestExplorer = new DotnetTestExplorer(context);
+    const testResults = new TestResultsFile();
+    context.subscriptions.push(testResults);
+
+    const dotnetTestExplorer = new DotnetTestExplorer(context, testResults);
     vscode.window.registerTreeDataProvider("dotnetTestExplorer", dotnetTestExplorer);
     AppInsightsClient.sendEvent("loadExtension");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,11 @@ export function activate(context: vscode.ExtensionContext) {
     const testResults = new TestResultsFile();
     context.subscriptions.push(testResults);
 
+    Utility.updateCache();
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
+        Utility.updateCache();
+    }));
+
     const dotnetTestExplorer = new DotnetTestExplorer(context, testResults);
     vscode.window.registerTreeDataProvider("dotnetTestExplorer", dotnetTestExplorer);
     AppInsightsClient.sendEvent("loadExtension");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { DotnetTestExplorer } from "./dotnetTestExplorer";
 import { Executor } from "./executor";
 import { TestNode } from "./testNode";
 import { TestResultsFile } from "./testResultsFile";
+import { TestStatusCodeLensProvider } from "./testStatusCodeLensProvider";
 import { Utility } from "./utility";
 
 export function activate(context: vscode.ExtensionContext) {
@@ -15,6 +16,12 @@ export function activate(context: vscode.ExtensionContext) {
     const dotnetTestExplorer = new DotnetTestExplorer(context, testResults);
     vscode.window.registerTreeDataProvider("dotnetTestExplorer", dotnetTestExplorer);
     AppInsightsClient.sendEvent("loadExtension");
+
+    const codeLensProvider = new TestStatusCodeLensProvider(testResults);
+    context.subscriptions.push(codeLensProvider);
+    context.subscriptions.push(vscode.languages.registerCodeLensProvider(
+        { language: 'csharp', scheme: 'file' },
+        codeLensProvider));
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.refreshTestExplorer", () => {
         dotnetTestExplorer.refreshTestExplorer();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
     const codeLensProvider = new TestStatusCodeLensProvider(testResults);
     context.subscriptions.push(codeLensProvider);
     context.subscriptions.push(vscode.languages.registerCodeLensProvider(
-        { language: 'csharp', scheme: 'file' },
+        { language: "csharp", scheme: "file" },
         codeLensProvider));
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.refreshTestExplorer", () => {

--- a/src/testResult.ts
+++ b/src/testResult.ts
@@ -1,0 +1,12 @@
+export class TestResult {
+    public constructor(private _name: string, private _outcome: string) {
+    }
+
+    public get testName(): string {
+        return this._name;
+    }
+
+    public get outcome(): string {
+        return this._outcome;
+    }
+}

--- a/src/testResult.ts
+++ b/src/testResult.ts
@@ -1,12 +1,37 @@
 export class TestResult {
-    public constructor(private _name: string, private _outcome: string) {
+    private className: string;
+    private method: string;
+
+    public constructor(private _testId: string, private _outcome: string) {
     }
 
-    public get testName(): string {
-        return this._name;
+    public get fullName(): string {
+        return this.className + "." + this.method;
+    }
+
+    public get id(): string {
+        return this._testId;
     }
 
     public get outcome(): string {
         return this._outcome;
+    }
+
+    public matches(className: string, method: string): boolean {
+        // The passed in class name won't have the namespace, hence the
+        // check with endsWith
+        return (this.method === method) && this.className.endsWith(className);
+    }
+
+    public updateName(className: string, method: string): void {
+        this.className = className;
+
+        // xUnit includes the class name in the name of the unit test
+        // i.e. classname.method
+        if (method.startsWith(className)) {
+            this.method = method.substring(className.length + 1); // +1 to include the .
+        } else {
+            this.method = method;
+        }
     }
 }

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -1,13 +1,13 @@
 "use strict";
 import * as fs from "fs";
 import * as path from "path";
-import { Disposable, EventEmitter, Event } from "vscode";
 import { setTimeout } from "timers";
+import { Disposable, Event, EventEmitter } from "vscode";
 import { DOMParser } from "xmldom";
-import { TestResult } from "./testResult"
+import { TestResult } from "./testResult";
 
 function getAttributeValue(node, name: string): string {
-    let attribute = node.attributes.getNamedItem(name);
+    const attribute = node.attributes.getNamedItem(name);
     return (attribute === null) ? null : attribute.nodeValue;
 }
 
@@ -18,15 +18,15 @@ export class TestResultsFile implements Disposable {
     private watcher: fs.FSWatcher;
 
     public constructor() {
-        const tempFolder = process.platform === "win32" ? process.env["TEMP"] : "/tmp";
+        const tempFolder = process.platform === "win32" ? process.env.TEMP : "/tmp";
         this.resultsFile = path.join(tempFolder, TestResultsFile.ResultsFileName);
 
         // The change event gets called multiple times, so use a one-second
         // delay before we read anything to avoid doing too much work
-        let me = this;
+        const me = this;
         let timeout: NodeJS.Timer;
         this.watcher = fs.watch(tempFolder, (eventType, fileName) => {
-            if ((fileName == TestResultsFile.ResultsFileName) && (eventType == "change")) {
+            if ((fileName === TestResultsFile.ResultsFileName) && (eventType === "change")) {
                 if (!timeout) {
                     timeout = setTimeout(() => {
                         timeout = null;
@@ -54,19 +54,18 @@ export class TestResultsFile implements Disposable {
     }
 
     private parseResults(): void {
-        console.log("Loading test results file '%s'", this.resultsFile);
-        const emitter = this.onNewResultsEmitter
+        const emitter = this.onNewResultsEmitter;
         fs.readFile(this.resultsFile, (err, data) => {
-            if (err) {
-                console.log("Error reading test results file: '%s'", err);
-            } else {
-                let results: TestResult[] = [];
+            if (!err) {
+                const results: TestResult[] = [];
                 const xdoc = new DOMParser().parseFromString(data.toString(), "application/xml");
                 const nodes = xdoc.documentElement.getElementsByTagName("UnitTestResult");
-                for (var i = 0; i < nodes.length; i++) {
+
+                // TSLint wants to use for-of here, but nodes doesn't support it
+                for (let i = 0; i < nodes.length; i++) { // tslint:disable-line
                     results.push(new TestResult(
                         getAttributeValue(nodes[i], "testName"),
-                        getAttributeValue(nodes[i], "outcome")
+                        getAttributeValue(nodes[i], "outcome"),
                     ));
                 }
 

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -3,10 +3,17 @@ import * as fs from "fs";
 import * as path from "path";
 import { Disposable, EventEmitter, Event } from "vscode";
 import { setTimeout } from "timers";
+import { DOMParser } from "xmldom";
+import { TestResult } from "./testResult"
+
+function getAttributeValue(node, name: string): string {
+    let attribute = node.attributes.getNamedItem(name);
+    return (attribute === null) ? null : attribute.nodeValue;
+}
 
 export class TestResultsFile implements Disposable {
     private static readonly ResultsFileName = "TestExplorerResults.trx";
-    private onResultsUpdatedEmmitter = new EventEmitter<void>();
+    private onNewResultsEmmitter = new EventEmitter<TestResult[]>();
     private resultsFile: string;
     private watcher: fs.FSWatcher;
 
@@ -42,12 +49,28 @@ export class TestResultsFile implements Disposable {
         return this.resultsFile;
     }
 
-    public get onResultsUpdated(): Event<void> {
-        return this.onResultsUpdatedEmmitter.event;
+    public get onNewResults(): Event<TestResult[]> {
+        return this.onNewResultsEmmitter.event;
     }
 
     private parseResults(): void {
-        console.log("Test results has changed.");
-        this.onResultsUpdatedEmmitter.fire();
+        console.log("Loading test results file '{0}'", this.resultsFile);
+        fs.readFile(this.resultsFile, (err, data) => {
+            if (err) {
+                console.log("Error reading test results file: '{0}'", err);
+            } else {
+                let results: TestResult[] = [];
+                const xdoc = new DOMParser().parseFromString(data.toString(), "application/xml");
+                const nodes = xdoc.documentElement.getElementsByTagName("UnitTestResult");
+                for (var i = 0; i < nodes.length; i++) {
+                    results.push(new TestResult(
+                        getAttributeValue(nodes[i], "testName"),
+                        getAttributeValue(nodes[i], "outcome")
+                    ));
+                }
+
+                this.onNewResultsEmmitter.fire(results);
+            }
+        });
     }
 }

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -24,15 +24,13 @@ export class TestResultsFile implements Disposable {
         // The change event gets called multiple times, so use a one-second
         // delay before we read anything to avoid doing too much work
         const me = this;
-        let timeout: NodeJS.Timer;
+        let changeDelay: NodeJS.Timer;
         this.watcher = fs.watch(tempFolder, (eventType, fileName) => {
             if ((fileName === TestResultsFile.ResultsFileName) && (eventType === "change")) {
-                if (!timeout) {
-                    timeout = setTimeout(() => {
-                        timeout = null;
-                        me.parseResults();
-                    }, 1000);
-                }
+                clearTimeout(changeDelay);
+                changeDelay = setTimeout(() => {
+                    me.parseResults();
+                }, 1000);
             }
         });
     }
@@ -41,7 +39,7 @@ export class TestResultsFile implements Disposable {
         try {
             this.watcher.close();
             fs.unlinkSync(this.resultsFile);
-        } catch {
+        } catch (error) {
         }
     }
 

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -1,0 +1,53 @@
+"use strict";
+import * as fs from "fs";
+import * as path from "path";
+import { Disposable, EventEmitter, Event } from "vscode";
+import { setTimeout } from "timers";
+
+export class TestResultsFile implements Disposable {
+    private static readonly ResultsFileName = "TestExplorerResults.trx";
+    private onResultsUpdatedEmmitter = new EventEmitter<void>();
+    private resultsFile: string;
+    private watcher: fs.FSWatcher;
+
+    public constructor() {
+        const tempFolder = process.platform === "win32" ? process.env["TEMP"] : "/tmp";
+        this.resultsFile = path.join(tempFolder, TestResultsFile.ResultsFileName);
+
+        // The change event gets called multiple times, so use a one-second
+        // delay before we read anything to avoid doing too much work
+        let me = this;
+        let timeout: NodeJS.Timer;
+        this.watcher = fs.watch(tempFolder, (eventType, fileName) => {
+            if ((fileName == TestResultsFile.ResultsFileName) && (eventType == "change")) {
+                if (!timeout) {
+                    timeout = setTimeout(() => {
+                        timeout = null;
+                        me.parseResults();
+                    }, 1000);
+                }
+            }
+        });
+    }
+
+    public dispose(): void {
+        try {
+            this.watcher.close();
+            fs.unlinkSync(this.resultsFile);
+        } catch {
+        }
+    }
+
+    public get fileName(): string {
+        return this.resultsFile;
+    }
+
+    public get onResultsUpdated(): Event<void> {
+        return this.onResultsUpdatedEmmitter.event;
+    }
+
+    private parseResults(): void {
+        console.log("Test results has changed.");
+        this.onResultsUpdatedEmmitter.fire();
+    }
+}

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -123,7 +123,7 @@ export class TestResultsFile implements Disposable {
         const me = this;
         let changeDelay: NodeJS.Timer;
         this.watcher = fs.watch(folder, (eventType, fileName) => {
-            if ((fileName === TestResultsFile.ResultsFileName) && (eventType === "change")) {
+            if (fileName === TestResultsFile.ResultsFileName) {
                 clearTimeout(changeDelay);
                 changeDelay = setTimeout(() => {
                     me.parseResults();

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -13,7 +13,7 @@ function getAttributeValue(node, name: string): string {
 
 export class TestResultsFile implements Disposable {
     private static readonly ResultsFileName = "TestExplorerResults.trx";
-    private onNewResultsEmmitter = new EventEmitter<TestResult[]>();
+    private onNewResultsEmitter = new EventEmitter<TestResult[]>();
     private resultsFile: string;
     private watcher: fs.FSWatcher;
 
@@ -50,14 +50,15 @@ export class TestResultsFile implements Disposable {
     }
 
     public get onNewResults(): Event<TestResult[]> {
-        return this.onNewResultsEmmitter.event;
+        return this.onNewResultsEmitter.event;
     }
 
     private parseResults(): void {
-        console.log("Loading test results file '{0}'", this.resultsFile);
+        console.log("Loading test results file '%s'", this.resultsFile);
+        const emitter = this.onNewResultsEmitter
         fs.readFile(this.resultsFile, (err, data) => {
             if (err) {
-                console.log("Error reading test results file: '{0}'", err);
+                console.log("Error reading test results file: '%s'", err);
             } else {
                 let results: TestResult[] = [];
                 const xdoc = new DOMParser().parseFromString(data.toString(), "application/xml");
@@ -69,7 +70,7 @@ export class TestResultsFile implements Disposable {
                     ));
                 }
 
-                this.onNewResultsEmmitter.fire(results);
+                emitter.fire(results);
             }
         });
     }

--- a/src/testStatusCodeLens.ts
+++ b/src/testStatusCodeLens.ts
@@ -1,0 +1,25 @@
+"use strict";
+import { CodeLens, Range } from "vscode";
+
+export class TestStatusCodeLens extends CodeLens {
+    public constructor(range: Range, status: string) {
+        super(range);
+
+        this.command = {
+            title: status,
+            command: null
+        };
+    }
+
+    public static parseOutcome(outcome: string): string {
+        if (outcome === "Passed") {
+            return "✔️";
+        } else if (outcome === "Failed") {
+            return "❌";
+        } else if (outcome === "NotExecuted") {
+            return "️️⚠️";
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/testStatusCodeLens.ts
+++ b/src/testStatusCodeLens.ts
@@ -1,14 +1,15 @@
 "use strict";
 import { CodeLens, Range } from "vscode";
+import { Utility } from "./utility";
 
 export class TestStatusCodeLens extends CodeLens {
     public static parseOutcome(outcome: string): string {
         if (outcome === "Passed") {
-            return "✔️";
+            return Utility.codeLensPassed;
         } else if (outcome === "Failed") {
-            return "❌";
+            return Utility.codeLensFailed;
         } else if (outcome === "NotExecuted") {
-            return "️️⚠️";
+            return Utility.codeLensSkipped;
         } else {
             return null;
         }

--- a/src/testStatusCodeLens.ts
+++ b/src/testStatusCodeLens.ts
@@ -2,15 +2,6 @@
 import { CodeLens, Range } from "vscode";
 
 export class TestStatusCodeLens extends CodeLens {
-    public constructor(range: Range, status: string) {
-        super(range);
-
-        this.command = {
-            title: status,
-            command: null
-        };
-    }
-
     public static parseOutcome(outcome: string): string {
         if (outcome === "Passed") {
             return "✔️";
@@ -21,5 +12,14 @@ export class TestStatusCodeLens extends CodeLens {
         } else {
             return null;
         }
+    }
+
+    public constructor(range: Range, status: string) {
+        super(range);
+
+        this.command = {
+            title: status,
+            command: null,
+        };
     }
 }

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -45,9 +45,8 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
             .then((symbols) => {
                 const mapped: CodeLens[] = [];
                 for (const symbol of symbols.filter((x) => x.kind === SymbolKind.Method)) {
-                    const fullName = symbol.containerName + "." + symbol.name;
                     for (const result of results.values()) {
-                        if (result.testName.endsWith(fullName)) {
+                        if (result.matches(symbol.containerName, symbol.name)) {
                             const state = TestStatusCodeLens.parseOutcome(result.outcome);
                             if (state) {
                                 mapped.push(new TestStatusCodeLens(symbol.location.range, state));
@@ -66,7 +65,7 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
 
     private addTestResults(results: TestResult[]) {
         for (const result of results) {
-            this.testResults.set(result.testName, result);
+            this.testResults.set(result.fullName, result);
         }
 
         this.onDidChangeCodeLensesEmitter.fire();

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -1,5 +1,5 @@
 "use strict";
-import { CancellationToken, commands, CodeLens, CodeLensProvider, Disposable, Event, EventEmitter, Range, SymbolInformation, TextDocument, workspace, SymbolKind } from "vscode";
+import { CancellationToken, CodeLens, CodeLensProvider, commands, Disposable, Event, EventEmitter, Range, SymbolInformation, SymbolKind, TextDocument, workspace } from "vscode";
 import { TestResult } from "./testResult";
 import { TestResultsFile } from "./testResultsFile";
 import { TestStatusCodeLens } from "./testStatusCodeLens";
@@ -17,7 +17,7 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
 
     public constructor(testResultFile: TestResultsFile) {
         this.checkEnabledOption();
-        
+
         this.disposables.push(
             testResultFile.onNewResults(this.addTestResults, this));
 
@@ -42,13 +42,13 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
 
         const results = this.testResults;
         return commands.executeCommand<SymbolInformation[]>("vscode.executeDocumentSymbolProvider", document.uri)
-            .then(symbols => {
-                let mapped: CodeLens[] = [];
-                for (let symbol of symbols.filter(x => x.kind === SymbolKind.Method)) {
-                    let fullName = symbol.containerName + '.' + symbol.name;
-                    for (let result of results.values()) {
+            .then((symbols) => {
+                const mapped: CodeLens[] = [];
+                for (const symbol of symbols.filter((x) => x.kind === SymbolKind.Method)) {
+                    const fullName = symbol.containerName + "." + symbol.name;
+                    for (const result of results.values()) {
                         if (result.testName.endsWith(fullName)) {
-                            let state = TestStatusCodeLens.parseOutcome(result.outcome);
+                            const state = TestStatusCodeLens.parseOutcome(result.outcome);
                             if (state) {
                                 mapped.push(new TestStatusCodeLens(symbol.location.range, state));
                             }
@@ -65,9 +65,9 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
     }
 
     private addTestResults(results: TestResult[]) {
-        for (let result of results) {
+        for (const result of results) {
             this.testResults.set(result.testName, result);
-        };
+        }
 
         this.onDidChangeCodeLensesEmitter.fire();
     }

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -1,5 +1,5 @@
 "use strict";
-import { CancellationToken, CodeLens, CodeLensProvider, commands, Disposable, Event, EventEmitter, Range, SymbolInformation, SymbolKind, TextDocument, workspace } from "vscode";
+import { CancellationToken, CodeLens, CodeLensProvider, commands, Disposable, Event, EventEmitter, Range, SymbolInformation, SymbolKind, TextDocument } from "vscode";
 import { TestResult } from "./testResult";
 import { TestResultsFile } from "./testResultsFile";
 import { TestStatusCodeLens } from "./testStatusCodeLens";
@@ -7,7 +7,6 @@ import { Utility } from "./utility";
 
 export class TestStatusCodeLensProvider implements CodeLensProvider {
     private disposables: Disposable[] = [];
-    private enabled: boolean;
     private onDidChangeCodeLensesEmitter = new EventEmitter<void>();
 
     // Store everything in a map so we can remember old tests results for the
@@ -17,13 +16,8 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
     private testResults = new Map<string, TestResult>();
 
     public constructor(testResultFile: TestResultsFile) {
-        this.checkEnabledOption();
-
         this.disposables.push(
             testResultFile.onNewResults(this.addTestResults, this));
-
-        this.disposables.push(
-            workspace.onDidChangeConfiguration(this.checkEnabledOption, this));
     }
 
     public dispose() {
@@ -37,7 +31,7 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
     }
 
     public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
-        if (!this.enabled) {
+        if (!Utility.codeLensEnabled()) {
             return [];
         }
 
@@ -70,9 +64,5 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
         }
 
         this.onDidChangeCodeLensesEmitter.fire();
-    }
-
-    private checkEnabledOption(): void {
-        this.enabled = Utility.getConfiguration().get<boolean>("showCodeLens", true);
     }
 }

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -3,6 +3,7 @@ import { CancellationToken, CodeLens, CodeLensProvider, commands, Disposable, Ev
 import { TestResult } from "./testResult";
 import { TestResultsFile } from "./testResultsFile";
 import { TestStatusCodeLens } from "./testStatusCodeLens";
+import { Utility } from "./utility";
 
 export class TestStatusCodeLensProvider implements CodeLensProvider {
     private disposables: Disposable[] = [];
@@ -72,6 +73,6 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
     }
 
     private checkEnabledOption(): void {
-        this.enabled = workspace.getConfiguration("csharp").get<boolean>("testsCodeLens.enabled", true);
+        this.enabled = Utility.getConfiguration().get<boolean>("showCodeLens", true);
     }
 }

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -1,0 +1,78 @@
+"use strict";
+import { CancellationToken, commands, CodeLens, CodeLensProvider, Disposable, Event, EventEmitter, Range, SymbolInformation, TextDocument, workspace, SymbolKind } from "vscode";
+import { TestResult } from "./testResult";
+import { TestResultsFile } from "./testResultsFile";
+import { TestStatusCodeLens } from "./testStatusCodeLens";
+
+export class TestStatusCodeLensProvider implements CodeLensProvider {
+    private disposables: Disposable[] = [];
+    private enabled: boolean;
+    private onDidChangeCodeLensesEmitter = new EventEmitter<void>();
+
+    // Store everything in a map so we can remember old tests results for the
+    // scenario where a single test is ran. If the test no longer exists in
+    // code it will never be mapped to the symbol, so no harm (though there is
+    // a memory impact)
+    private testResults = new Map<string, TestResult>();
+
+    public constructor(testResultFile: TestResultsFile) {
+        this.checkEnabledOption();
+        
+        this.disposables.push(
+            testResultFile.onNewResults(this.addTestResults, this));
+
+        this.disposables.push(
+            workspace.onDidChangeConfiguration(this.checkEnabledOption, this));
+    }
+
+    public dispose() {
+        while (this.disposables.length) {
+            this.disposables.pop().dispose();
+        }
+    }
+
+    public get onDidChangeCodeLenses(): Event<void> {
+        return this.onDidChangeCodeLensesEmitter.event;
+    }
+
+    public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
+        if (!this.enabled) {
+            return [];
+        }
+
+        const results = this.testResults;
+        return commands.executeCommand<SymbolInformation[]>("vscode.executeDocumentSymbolProvider", document.uri)
+            .then(symbols => {
+                let mapped: CodeLens[] = [];
+                for (let symbol of symbols.filter(x => x.kind === SymbolKind.Method)) {
+                    let fullName = symbol.containerName + '.' + symbol.name;
+                    for (let result of results.values()) {
+                        if (result.testName.endsWith(fullName)) {
+                            let state = TestStatusCodeLens.parseOutcome(result.outcome);
+                            if (state) {
+                                mapped.push(new TestStatusCodeLens(symbol.location.range, state));
+                            }
+                        }
+                    }
+                }
+
+                return mapped;
+            });
+    }
+
+    public resolveCodeLens(codeLens: CodeLens, token: CancellationToken): CodeLens {
+        return codeLens;
+    }
+
+    private addTestResults(results: TestResult[]) {
+        for (let result of results) {
+            this.testResults.set(result.testName, result);
+        };
+
+        this.onDidChangeCodeLensesEmitter.fire();
+    }
+
+    private checkEnabledOption(): void {
+        this.enabled = workspace.getConfiguration("csharp").get<boolean>("testsCodeLens.enabled", true);
+    }
+}

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -31,7 +31,7 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
     }
 
     public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | Thenable<CodeLens[]> {
-        if (!Utility.codeLensEnabled()) {
+        if (!Utility.codeLensEnabled) {
             return [];
         }
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -28,9 +28,9 @@ export class Utility {
         const osx = platform() === "darwin";
 
         Utility.showCodeLens = configuration.get<boolean>("showCodeLens", true);
-        Utility.failed = Utility.getLensText(configuration, "codeLensPassed", "\u274c"); // Cross Mark
+        Utility.failed = Utility.getLensText(configuration, "codeLensFailed", "\u274c"); // Cross Mark
         Utility.passed = Utility.getLensText(configuration, "codeLensPassed", osx ? "\u2705" : "\u2714"); // White Heavy Check Mark / Heavy Check Mark
-        Utility.skipped = Utility.getLensText(configuration, "codeLensPassed", "\u26a0"); // Warning
+        Utility.skipped = Utility.getLensText(configuration, "codeLensSkipped", "\u26a0"); // Warning
     }
 
     private static showCodeLens: boolean;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,12 +1,49 @@
 "use strict";
+import { platform } from "os";
 import * as vscode from "vscode";
 
 export class Utility {
-    public static codeLensEnabled(): boolean {
-        return Utility.getConfiguration().get<boolean>("showCodeLens", true);
+    private static showCodeLens: boolean;
+    private static failed: string;
+    private static passed: string;
+    private static skipped: string;
+
+    public static get codeLensEnabled(): boolean {
+        return Utility.showCodeLens;
+    }
+
+    public static get codeLensFailed(): string {
+        return Utility.failed;
+    }
+
+    public static get codeLensPassed(): string {
+        return Utility.passed;
+    }
+
+    public static get codeLensSkipped(): string {
+        return Utility.skipped;
     }
 
     public static getConfiguration(): vscode.WorkspaceConfiguration {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
+    }
+
+    public static updateCache() {
+        const configuration = Utility.getConfiguration();
+        const osx = platform() === "darwin";
+
+        Utility.showCodeLens = configuration.get<boolean>("showCodeLens", true);
+        Utility.failed = Utility.getLensText(configuration, "codeLensPassed", "\u274c"); // Cross Mark
+        Utility.passed = Utility.getLensText(configuration, "codeLensPassed", osx ? "\u2705" : "\u2714"); // White Heavy Check Mark / Heavy Check Mark
+        Utility.skipped = Utility.getLensText(configuration, "codeLensPassed", "\u26a0"); // Warning
+    }
+
+    private static getLensText(configuration: vscode.WorkspaceConfiguration, name: string, fallback: string): string {
+        // This is an invisible character that indicates the previous character
+        // should be displayed as an emoji, which in our case adds some colour
+        const emojiVariation = "\ufe0f";
+
+        const setting = configuration.get<string>(name);
+        return setting ? setting : (fallback + emojiVariation);
     }
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -3,11 +3,6 @@ import { platform } from "os";
 import * as vscode from "vscode";
 
 export class Utility {
-    private static showCodeLens: boolean;
-    private static failed: string;
-    private static passed: string;
-    private static skipped: string;
-
     public static get codeLensEnabled(): boolean {
         return Utility.showCodeLens;
     }
@@ -37,6 +32,11 @@ export class Utility {
         Utility.passed = Utility.getLensText(configuration, "codeLensPassed", osx ? "\u2705" : "\u2714"); // White Heavy Check Mark / Heavy Check Mark
         Utility.skipped = Utility.getLensText(configuration, "codeLensPassed", "\u26a0"); // Warning
     }
+
+    private static showCodeLens: boolean;
+    private static failed: string;
+    private static passed: string;
+    private static skipped: string;
 
     private static getLensText(configuration: vscode.WorkspaceConfiguration, name: string, fallback: string): string {
         // This is an invisible character that indicates the previous character

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -2,6 +2,10 @@
 import * as vscode from "vscode";
 
 export class Utility {
+    public static codeLensEnabled(): boolean {
+        return Utility.getConfiguration().get<boolean>("showCodeLens", true);
+    }
+
     public static getConfiguration(): vscode.WorkspaceConfiguration {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
     }


### PR DESCRIPTION
Hope you don't mind me suggesting an enhancement. Also, it's my first foray into TypeScript so happy to change things to match your preferences. I wanted to display the test result status next to the method, like VS does so I looked at getting the results from the most recent test run.:

![preview](https://user-images.githubusercontent.com/1365438/32752198-3e3c09c8-c8c0-11e7-87f9-444f285a8502.png)

The results are outputted to a TRX file and then that file is parsed to get the test results. Finally, the `vscode.executeDocumentSymbolProvider` command is used to get all the symbols in the current document to match the method to the test name.

Things to note. I've tested it with xUnit - it probably needs checking with NUnit as well. Also, I'm using emoji's to display the results, as you can only have text in the CodeLens. This looks fine on Windows 10 but might need a switch to use normal text instead of emoji's in case it looks wrong on other OS's.

Finally, there are things I'd like to enhance but not sure how to implement. I'd like it so you can click on the status and a popup show you the test output (useful for failing tests).
