### PR TITLE
wrapping command line option in quotes

### DIFF
--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -88,7 +88,7 @@ export class TestCommands {
         let command = `dotnet test${this.getDotNetTestOptions()}${this.outputTestResults()}`;
 
         if (testName && testName.length) {
-            command = command + ` --filter FullyQualifiedName~${testName.replace(/\(.*\)/g, "")}`;
+            command = command + ` --filter "FullyQualifiedName~${testName.replace(/\(.*\)/g, "")}"`;
         }
 
         this.lastRunTestName = testName;


### PR DESCRIPTION
F# methods can have spaces in their names.  I've added quotes around the filter options as this included the test name which would then fail if the name had spaces in it

I have tested the explorer against the MS samples app which features F# xunit tests with names with spaces in them and the explorer works 