### PR TITLE
Adding double quotes to filter command line option...plus test

### DIFF
--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -88,7 +88,7 @@ export class TestCommands {
         let command = `dotnet test${this.getDotNetTestOptions()}${this.outputTestResults()}`;
 
         if (testName && testName.length) {
-            command = command + ` --filter FullyQualifiedName~${testName.replace(/\(.*\)/g, "")}`;
+            command = command + ` --filter "FullyQualifiedName~${testName.replace(/\(.*\)/g, "")}"`;
         }
 
         this.lastRunTestName = testName;

--- a/test/fsxunittests/FSharpTests.fsproj
+++ b/test/fsxunittests/FSharpTests.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TestClass1.fs"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/test/fsxunittests/TestClass1.fs
+++ b/test/fsxunittests/TestClass1.fs
@@ -1,0 +1,8 @@
+module FSharpTests
+
+open Xunit
+open Shouldly
+
+[<Fact>]
+let ``This is a test that has spaces in it's name`` () =
+   (true).ShouldBe(true)


### PR DESCRIPTION
I've quoted the filter argument to allow for tests with spaces in their names.

I've also added an F# project to the tests with a single passing test that has a space in its name and confirmed that it 