### PR TITLE
Make left clicking on test open test by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,16 @@
           "type": "string",
           "default": "",
           "description": "Additional arguments that are added to the dotnet test command."
+        },
+        "dotnet-test-explorer.leftClickAction": {
+          "type": "string",
+          "default": "gotoTest",
+          "enum": [
+            "gotoTest",
+            "runTest",
+            "doNothing"
+          ],
+          "description": "What happens when a test in the list is left clicked."
         }
       }
     },

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -64,6 +64,11 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
                 light: this.context.asAbsolutePath(path.join("resources", "light", element.icon)),
             } : void 0,
             contextValue: element.isFolder ? "folder" : "test",
+            command: element.isFolder ? null : {
+                command: "dotnet-test-explorer.leftClickTest",
+                title: "",
+                arguments: [element],
+            },
         };
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { DotnetTestExplorer } from "./dotnetTestExplorer";
 import { Executor } from "./executor";
 import { FindTestInContext } from "./findTestInContext";
 import { GotoTest } from "./gotoTest";
+import { LeftClickTest } from "./leftClickTest";
 import { Logger } from "./logger";
 import { MessagesController } from "./messages";
 import { Problems } from "./problems";
@@ -28,6 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
     const problems = new Problems(testCommands);
     const statusBar = new StatusBar();
     const watch = new Watch(testCommands, testDirectories, testResults);
+    const leftClickTest = new LeftClickTest();
 
     Logger.Log("Starting extension");
 
@@ -83,6 +85,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.rerunLastCommand", (test: TestNode) => {
         testCommands.rerunLastCommand();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.leftClickTest", (test: TestNode) => {
+        leftClickTest.handle(test);
     }));
 
     context.subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {

--- a/src/leftClickTest.ts
+++ b/src/leftClickTest.ts
@@ -1,0 +1,16 @@
+import * as vscode from "vscode";
+import { TestNode } from "./testNode";
+import { Utility } from "./utility";
+
+export class LeftClickTest {
+    public handle(test: TestNode): void {
+        const leftClickAction = Utility.getConfiguration().get<string>("leftClickAction");
+        if (leftClickAction === "gotoTest") {
+            vscode.commands.executeCommand("dotnet-test-explorer.gotoTest", test);
+        }
+
+        if (leftClickAction === "runTest") {
+            vscode.commands.executeCommand("dotnet-test-explorer.runTest", test);
+        }
+    }
+}


### PR DESCRIPTION
User can configure this behaviour via leftClickAction to either:
- runTest
- goToTest
- doNothing
When user clicks a test, this is initially handled by leftClickTest
  command which checks configuration and then passes request to
  appropriate handler. This ensures that when user changes configuration,
  the next click is handled correctly.

Replaces #108 