### PR TITLE
Fix unfound tests when using Go to Test feature with F#

### DIFF
--- a/src/gotoTest.ts
+++ b/src/gotoTest.ts
@@ -46,7 +46,7 @@ export class GotoTest {
 
         const testName = this.getTestName(testNode.name);
 
-        symbols = symbols.filter( (s) => s.kind === vscode.SymbolKind.Method && this.getTestName(s.name) === testName);
+        symbols = symbols.filter((s) => this.isSymbolATestCandidate(s) && this.getTestName(s.name) === testName);
 
         if (symbols.length === 0) {
             throw Error("Could not find test (no symbols matching)");
@@ -93,5 +93,9 @@ export class GotoTest {
         }
 
         return testNode.parentPath;
+    }
+
+    private isSymbolATestCandidate(s: vscode.SymbolInformation): boolean {
+        return s.location.uri.toString().endsWith(".fs") ? s.kind === vscode.SymbolKind.Variable : s.kind === vscode.SymbolKind.Method;
     }
 }

--- a/test/gotoTest.test.ts
+++ b/test/gotoTest.test.ts
@@ -41,6 +41,32 @@ suite("Find test location", () => {
         assert.equal(result.location.uri.fsPath, vscode.Uri.parse("c:\\temp\\test.txt").fsPath);
     });
 
+    test("One F# symbol matching", () => {
+        const symbols = [
+            GetSymbol("Test", vscode.SymbolKind.Variable, "c:\\temp\\test.fs"),
+        ];
+
+        const testNode = new TestNode("", "Test", null);
+
+        const gotoTest = new GotoTest();
+        const result = gotoTest.findTestLocation(symbols, testNode);
+
+        assert.equal(result.location.uri.fsPath, vscode.Uri.parse("c:\\temp\\test.fs").fsPath);
+    });
+
+    test("One F# symbol with spaces matching", () => {
+        const symbols = [
+            GetSymbol("Test with spaces", vscode.SymbolKind.Variable, "c:\\temp\\test.fs"),
+        ];
+
+        const testNode = new TestNode("", "Test with spaces", null);
+
+        const gotoTest = new GotoTest();
+        const result = gotoTest.findTestLocation(symbols, testNode);
+
+        assert.equal(result.location.uri.fsPath, vscode.Uri.parse("c:\\temp\\test.fs").fsPath);
+    });
+
     test("Multiple symbols matching with no namespace matching uri", () => {
         const symbols = [
             GetSymbol("Test",  vscode.SymbolKind.Method, "file:\\c:/temp/folderx/test.txt"),


### PR DESCRIPTION
Hi, 
I found when trying to go to tests in my F# project, I got a symbol not found error. I thought I would have a go at trying to fix it myself and so created a pull request.

I found the problem was that Ionide returns symbols for F# test functions as SymbolType.Variable (not sure why a variable and not a function), whereas currently symbols are filtered to be SymbolType.Method. Therefore, I added a check on the file extension and if it's a .fs I filter to be SymbolType.Variable. I also added a couple of tests.
