### PR TITLE
[#21] Double-quote argument to dotnet --filter

### DIFF
--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -148,9 +148,9 @@ export class TestCommands {
 
             if (testName && testName.length) {
                 if (isSingleTest) {
-                    command = command + ` --filter FullyQualifiedName=${testName.replace(/\(.*\)/g, "")}`;
+                    command = command + ` --filter "FullyQualifiedName=${testName.replace(/\(.*\)/g, "")}"`;
                 } else {
-                    command = command + ` --filter FullyQualifiedName~${testName.replace(/\(.*\)/g, "")}`;
+                    command = command + ` --filter "FullyQualifiedName~${testName.replace(/\(.*\)/g, "")}"`;
                 }
             }
 


### PR DESCRIPTION
The original fix was inadvertently reverted; this restores it.