### PR TITLE
Attempt to address issue #201

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -78,6 +78,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "${workspaceRoot}/test/tested",
                 "${workspaceRoot}/test/xunittests",
                 "${workspaceRoot}/test/nunit",
                 "${workspaceRoot}/test/fsxunittests",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,9 +2116,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.get": {
@@ -2244,9 +2244,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -2968,9 +2968,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -3489,35 +3489,14 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unset-value": {

--- a/src/dotnetTestExplorer.ts
+++ b/src/dotnetTestExplorer.ts
@@ -156,6 +156,7 @@ export class DotnetTestExplorer implements TreeDataProvider<TestNode> {
     private updateWithDiscoveredTests(results: IDiscoverTestsResult[]) {
         this.allNodes = [];
         this.discoveredTests = [].concat(...results.map( (r) => r.testNames));
+        this.discoveredTests = this.discoveredTests.sort();
         this.statusBar.discovered(this.discoveredTests.length);
         this._onDidChangeTreeData.fire();
     }

--- a/src/testResultsFile.ts
+++ b/src/testResultsFile.ts
@@ -51,11 +51,23 @@ function updateUnitTestDefinitions(xml: Element, results: TestResult[]): void {
 
     for (let i = 0; i < nodes.length; i++) { // tslint:disable-line
         const id = getAttributeValue(nodes[i], "id");
+        const name = getAttributeValue(nodes[i], "name");
         const testMethod = findChildElement(nodes[i], "TestMethod");
         if (testMethod) {
+            const isXUnit = getAttributeValue(testMethod, "adapterTypeName").toLowerCase().includes("xunit");
+            let className = getAttributeValue(testMethod, "className");
+            let method = getAttributeValue(testMethod, "name");
+            const shouldSplitName = isXUnit && !name.startsWith(className);
+            if (shouldSplitName) {
+                const parts = name.split(".");
+                if (parts.length > 0) {
+                    className = parts.slice(0, parts.length - 1).join(".");
+                    method = parts[parts.length - 1];
+                }
+            }
             names.set(id, {
-                className: getAttributeValue(testMethod, "className"),
-                method: getAttributeValue(testMethod, "name"),
+                className,
+                method,
             });
         }
     }

--- a/test/fsxunittests/FSharpTests.fsproj
+++ b/test/fsxunittests/FSharpTests.fsproj
@@ -8,11 +8,16 @@
 
   <ItemGroup>
     <Compile Include="TestClass1.fs"/>
+    <Compile Include="TestClass2.fs"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\tested\tested.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/fsxunittests/TestClass1.fs
+++ b/test/fsxunittests/TestClass1.fs
@@ -6,3 +6,7 @@ open Shouldly
 [<Fact>]
 let ``This is a test that has spaces in it's name`` () =
    (true).ShouldBe(true)
+
+[<Fact>]
+let ``This is a test that has (parens) in it's name`` () =
+   (true).ShouldBe(true)

--- a/test/fsxunittests/TestClass2.fs
+++ b/test/fsxunittests/TestClass2.fs
@@ -1,0 +1,12 @@
+module VSCodeDotnetTestExplorer.Testing.ObjectUnderTest.FSharpTests
+
+open Xunit
+open Shouldly
+open VSCodeDotnetTestExplorer.Testing.ObjectUnderTest
+
+[<Fact>]
+let ``This should pass`` () =
+    let expected = "expected"
+    let tested = new Tested()
+    let actual = (tested.ReturnString(expected))
+    (expected).ShouldBe(actual)

--- a/test/mstest/MSTestTests.csproj
+++ b/test/mstest/MSTestTests.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Shouldly" Version="3.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\tested\tested.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/test/mstest/TestClass3.cs
+++ b/test/mstest/TestClass3.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace VSCodeDotnetTestExplorer.Testing.ObjectUnderTest.MSTests
+{
+    [TestClass]
+    public class TestClass3
+    {
+        [TestMethod]
+        public void Pass()
+        {
+            string expected = "expected";
+            var tested = new Tested();
+            var actual = tested.ReturnString(expected);
+
+            (actual).ShouldBe(expected);
+        }
+
+    }
+}

--- a/test/nunit/NunitTests.csproj
+++ b/test/nunit/NunitTests.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\tested\tested.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/test/nunit/TestClass4.cs
+++ b/test/nunit/TestClass4.cs
@@ -1,0 +1,20 @@
+using System;
+using NUnit.Framework;
+using Shouldly;
+using VSCodeDotnetTestExplorer.Testing.ObjectUnderTest;
+
+namespace VSCodeDotnetTestExplorer.Testing.ObjectUnderTest.NUnitTests
+{
+    public class TestClass4
+    {
+        [Test]
+        public void Pass()
+        {
+            string expected = "expected";
+            var tested = new Tested();
+            var actual = tested.ReturnString(expected);
+
+            (actual).ShouldBe(expected);
+        }
+    }
+}

--- a/test/tested/tested.cs
+++ b/test/tested/tested.cs
@@ -1,0 +1,15 @@
+namespace VSCodeDotnetTestExplorer.Testing.ObjectUnderTest
+{
+    public class Tested
+    {
+        public string ReturnString(string value)
+        {
+            return value;
+        }
+
+        public int ReturnInt(int value)
+        {
+            return value;
+        }
+    }
+}

--- a/test/tested/tested.csproj
+++ b/test/tested/tested.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+  </ItemGroup>
+
+</Project>

--- a/test/workspace.code-workspace
+++ b/test/workspace.code-workspace
@@ -1,6 +1,9 @@
 {
 	"folders": [
 		{
+			"path": "tested"
+		},
+		{
 			"path": "xunittests"
 		},
 		{

--- a/test/xunittests/TestClass1.cs
+++ b/test/xunittests/TestClass1.cs
@@ -47,6 +47,12 @@ namespace XunitTests
 
         }
 
+        [Fact(DisplayName="XunitTests.TestClass1.xUnit Test with a different DisplayName")]
+        public void PassWithDisplayName()
+        {
+            (1+1).ShouldBe(2);
+        }
+
         // [Fact]
         // public void Fail()
         // {

--- a/test/xunittests/TestClass5.cs
+++ b/test/xunittests/TestClass5.cs
@@ -1,0 +1,52 @@
+using System;
+using Shouldly;
+using Xunit;
+using VSCodeDotnetTestExplorer.Testing.ObjectUnderTest;
+
+namespace VSCodeDotnetTestExplorer.Testing.ObjectUnderTest.XUnitTests
+{
+    public class TestClass5
+    {
+        [Fact]
+        public void Pass()
+        {
+            string expected = "expected";
+            var tested = new Tested();
+            var actual = tested.ReturnString(expected);
+
+            (actual).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void Pass2()
+        {
+            int expected = 1;
+            var tested = new Tested();
+            var actual = tested.ReturnInt(expected);
+
+            (actual).ShouldBe(expected);
+        }
+
+        [Fact(DisplayName="VSCodeDotnetTestExplorer.Testing.ObjectUnderTest.XUnitTests.TestClass5.xUnit Test with a (.) different DisplayName in a different namespace")]
+        public void PassWithDisplayName()
+        {
+            var expected = "DisplayName";
+            var tested = new Tested();
+            var actual = tested.ReturnString(expected);
+
+            (actual).ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void PassTheory(int value)
+        {
+            var tested = new Tested();
+            var actual = tested.ReturnInt(value);
+
+            (actual).ShouldBe(value);
+        }
+
+    }
+}

--- a/test/xunittests/XunitTests.csproj
+++ b/test/xunittests/XunitTests.csproj
@@ -14,4 +14,8 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\tested\tested.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Test classes with namespace that doesn't match assembly name cause TreeView to get out of sync**

It seems that this is only related to XUnit tests, and only `[Fact]` tests.

Aside from changes to 'testResultsFile.ts' and the various test projects, the following changes were made :

- updated packages to address npm audit findings
- added a call to sort on initially discovered tests (the tests are sorted when new ones are added, this helps keep the TreeView consistent)
