### PR TITLE
fix for extracting assembly name from dotnet test std out

### DIFF
--- a/src/testDiscovery.ts
+++ b/src/testDiscovery.ts
@@ -78,18 +78,25 @@ function extractTestNames(testCommandStdout: string): string[] {
 }
 
 function extractAssemblyPaths(testCommandStdout: string): string[] {
-    const testRunLineRegex = /^Test run for (.+\.dll)\(.+\)/gm;
+    let results = extractFirstRegexMatch(testCommandStdout, /^Test run for (.+\.dll)\(.+\)/gm);
+    if(results.length == 0)
+    {
+        // fix for dotnet 3.0 or output in other languages.
+        results = extractFirstRegexMatch(testCommandStdout, /^.*"(.+\.dll)"\s*\(.+\)/gm);
+
+    }
+    return results;
+}
+
+function extractFirstRegexMatch(testCommandStdout: string, regex: RegExp) {
     const results = [];
     let match = null;
-
     do {
-        match = testRunLineRegex.exec(testCommandStdout);
+        match = regex.exec(testCommandStdout);
         if (match) {
             results.push(match[1]);
         }
-    }
-    while (match);
-
+    } while (match);
     return results;
 }
 


### PR DESCRIPTION
had to adapt the regex for my machine, maybe this is usefull for others as well. Not sure if it is a caused by dotnet 3.0 or my machine culture is set to german