### PR TITLE
Allow a .env file to be loaded 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Text from the dotnet test output as well as debug info is written to the Output/
 * `dotnet-test-explorer.testArguments`: Additional arguments that are added to the dotnet test command
 * `dotnet-test-explorer.leftClickAction`: What happens when a test in the list is left clicked. (Default is **gotoTest**)
 * `dotnet-test-explorer.runInParallel`: If true, will discover/build and run test in parallel if you have multiple test projects (Default is **false**)
+* `dotnet-test-explorer.envFilePath` : Relative path to a .env from the workspace root directory, to be loaded for each test run
 
 ## Known issues
 ##### Go to test does not work with multiple workspaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,6 +762,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -242,6 +242,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, will discover/build and run test in parallel if you have multiple test projects"
+        },
+        "dotnet-test-explorer.envFilePath": {
+          "type": "string",
+          "default": "",
+          "description": "Relative path to a .env from the workspace root directory, to be loaded for each test run"
         }
       }
     },
@@ -285,6 +290,7 @@
   "dependencies": {
     "applicationinsights": "^1.0.5",
     "chokidar": "^2.1.0",
+    "dotenv": "^8.2.0",
     "fkill": "^5.3.0",
     "glob": "^7.1.2",
     "ts-node": "^7.0.1",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -6,6 +6,8 @@ import * as vscode from "vscode";
 import { Debug, IDebugRunnerInfo } from "./debug";
 import { Logger } from "./logger";
 
+import { Utility } from "./utility";
+
 export class Executor {
 
     public static runInTerminal(command: string, cwd?: string, addNewLine: boolean = true, terminal: string = "Test Explorer"): void {
@@ -25,7 +27,15 @@ export class Executor {
         process.env.DOTNET_CLI_UI_LANGUAGE = "en";
         process.env.VSTEST_HOST_DEBUG = "0";
 
-        const childProcess = exec(this.handleWindowsEncoding(command), { encoding: "utf8", maxBuffer: 5120000, cwd }, callback);
+        let childProcess: ChildProcess;
+        if (Utility.envFileSet) {
+            const envFile = Utility.envFileContents;
+            const env = {};
+            Object.assign(env, process.env, envFile);
+            childProcess = exec(this.handleWindowsEncoding(command), { encoding: "utf8", maxBuffer: 5120000, cwd, env }, callback);
+        } else {
+            childProcess = exec(this.handleWindowsEncoding(command), { encoding: "utf8", maxBuffer: 5120000, cwd }, callback);
+        }
 
         if (addToProcessList) {
 


### PR DESCRIPTION
Often times during testing our team makes use of environment variables for things like connection strings to testing databases. If these environment variables could be loaded in the context of when the tests are run it would allow us to tighten our inner development cycle and interact with our test suite much more efficiently 