### PR TITLE
Add openPanel command to and set Status Bar command to trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,10 @@
       {
         "command": "dotnet-test-explorer.debugTest",
         "title": "Debug Test"
+      },
+      {
+        "command": "dotnet-test-explorer.openPanel",
+        "title": "Open Tests Panel"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,10 @@ export function activate(context: vscode.ExtensionContext) {
         Logger.Show();
     }));
 
+    context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.openPanel", () => {
+        vscode.commands.executeCommand("workbench.view.extension.test");
+    }));
+
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.stop", () => {
         Executor.stop();
         dotnetTestExplorer.refreshTestExplorer();

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -9,6 +9,7 @@ export class StatusBar {
     public constructor(testCommand: TestCommands) {
         this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
         testCommand.onTestDiscoveryStarted(this.updateWithDiscoveringTest, this);
+        this.status.command = "dotnet-test-explorer.openPanel";
         this.discovering();
     }
 


### PR DESCRIPTION
I found it annoying that I could click on Problems and see failing tests (with `dotnet-test-explorer.addProblems = true`) but I couldn't click on the Tests status bar icon to open the tree view. This adds that functionality, so clicking on this area will trigger the Tests explorer to open. 
![image](https://user-images.githubusercontent.com/7868899/75400409-cdee4400-58c4-11ea-822a-a4f967cec60b.png)

Closes #245 which I opened.
