### PR TITLE
Add missing whitespaces between arguments

### DIFF
--- a/src/testDiscovery.ts
+++ b/src/testDiscovery.ts
@@ -46,7 +46,7 @@ export function discoverTests(testDirectoryPath: string, dotnetTestOptions: stri
 
 function executeDotnetTest(testDirectoryPath: string, dotnetTestOptions: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        const command = `dotnet test -t -v=q${dotnetTestOptions}`;
+        const command = `dotnet test -t -v=q ${dotnetTestOptions}`;
 
         Logger.Log(`Executing ${command} in ${testDirectoryPath}`);
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -41,7 +41,7 @@ export class Watch {
         const trxPath = path.join(this.testCommands.testResultFolder, `autoWatch${index}.trx`);
 
         AppInsightsClient.sendEvent("runWatchCommand");
-        const command = `dotnet watch test${Utility.additionalArgumentsOption} --logger "trx;LogFileName=${trxPath}"`;
+        const command = `dotnet watch test ${Utility.additionalArgumentsOption} --logger "trx;LogFileName=${trxPath}"`;
 
         Logger.Log(`Executing ${command} in ${testDirectory}`);
         const p = Executor.exec(command, (err: any, stdout: string) => {


### PR DESCRIPTION
Tiny fix: I noticed that additional options to `dotnet test` are appended without whitespace, which is probably not intended and could lead to hard-to-track bugs.