### PR TITLE
Do not rediscover test when user stops the process

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.stop", () => {
         Executor.stop();
-        dotnetTestExplorer.refreshTestExplorer();
+        dotnetTestExplorer._onDidChangeTreeData.fire(null);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.refreshTestExplorer", () => {

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -194,7 +194,9 @@ export class TestCommands implements Disposable {
             this.sendNewTestResults({ clearPreviousTestResults: testName === "", testResults: allTestResults });
         } catch (err) {
             Logger.Log(`Error while executing test command: ${err}`);
-            this.discoverTests();
+            if (err.message !== "UserAborted") {
+                this.discoverTests();
+            }
         }
         this.isRunning = false;
     }


### PR DESCRIPTION
It kinda grinds my gears that the entire test explorer refreshes, with all test results gone, whenever the user stops a process. This small PR should fix it.

Side note: why are tests rediscovered *at all* when there was an exception? Isn't this just going to cause loops, where a failure of test discovery will keep discovering tests forever? I struggle to see the reasoning behind this and am advocating to remove it alltogether. [(I'm talking about this line.](https://github.com/formulahendry/vscode-dotnet-test-explorer/compare/master...GeorchW:no-discovery-on-stop?expand=1#diff-a11752c66c36bd881633ed085b56fee5R197-R199) Git blame says that [it was added together with the stop command.](https://github.com/formulahendry/vscode-dotnet-test-explorer/commit/4ce8c228c78bafb1f81f8011dc87de9f65cd1c98#diff-a11752c66c36bd881633ed085b56fee5R118))