### PR TITLE
Improve test discovery experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "viewsWelcome": [
       {
         "view": "dotnetTestExplorer",
-        "contents": "No tests found. \n\nPlease open or set the test project and ensure your project compiles."
+        "contents": "No tests found. \n\nPlease open the test project and ensure your project compiles. If the directory to execute dotnet test in is not the workspace root, consider setting dotnet-test-explorer.testProjectPath appropriately.\n[Open settings](command:workbench.action.openSettings?%5B%22dotnet-test-explorer.testProjectPath%22%5D)"
       }
     ],
     "views": {
@@ -185,7 +185,7 @@
         },
         "dotnet-test-explorer.testProjectPath": {
           "type": "string",
-          "default": "",
+          "default": "{*.sln,**/*Test.@(cs|fs)proj,**/*Tests.@(cs|fs)proj}",
           "description": "Glob pattern that points to path of .NET Core test project(s)."
         },
         "dotnet-test-explorer.treeMode": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "viewsWelcome": [
       {
         "view": "dotnetTestExplorer",
-        "contents": "No tests found. \n\nPlease open the test project and ensure your project compiles.\nIf the directory to execute dotnet test in is not the workspace root, consider setting dotnet-test-explorer.testProjectPath appropriately.\n[Open settings](command:workbench.action.openSettings?%5B%22dotnet-test-explorer.testProjectPath%22%5D)"
+        "contents": "No tests found. \n\nPlease open the test project and ensure your project compiles.\nIf the directory to execute dotnet test in is not the workspace root, consider setting dotnet-test-explorer.testProjectPath appropriately.\n[Open settings](command:workbench.action.openWorkspaceSettingsFile)"
       }
     ],
     "views": {

--- a/package.json
+++ b/package.json
@@ -185,8 +185,13 @@
         },
         "dotnet-test-explorer.testProjectPath": {
           "type": "string",
-          "default": "{*.sln,**/*Test.@(cs|fs)proj,**/*Tests.@(cs|fs)proj}",
-          "description": "Glob pattern that points to path of .NET Core test project(s)."
+          "default": "",
+          "description": "Glob pattern that points to path of .NET Core test project(s).",
+          "examples": [
+            "**/*Test.@(csproj|vbproj|fsproj)",
+            "**/*Tests.@(csproj|vbproj|fsproj)",
+            "**/*.sln"
+          ]
         },
         "dotnet-test-explorer.treeMode": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "viewsWelcome": [
       {
         "view": "dotnetTestExplorer",
-        "contents": "No tests found. \n\nPlease open the test project and ensure your project compiles. If the directory to execute dotnet test in is not the workspace root, consider setting dotnet-test-explorer.testProjectPath appropriately.\n[Open settings](command:workbench.action.openSettings?%5B%22dotnet-test-explorer.testProjectPath%22%5D)"
+        "contents": "No tests found. \n\nPlease open the test project and ensure your project compiles.\nIf the directory to execute dotnet test in is not the workspace root, consider setting dotnet-test-explorer.testProjectPath appropriately.\n[Open settings](command:workbench.action.openSettings?%5B%22dotnet-test-explorer.testProjectPath%22%5D)"
       }
     ],
     "views": {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -7,7 +7,7 @@ import { Logger } from "./logger";
 
 export class Executor {
 
-    public static runInTerminal(command: string, cwd?: string, addNewLine: boolean = true, terminal: string = "Test Explorer"): void {
+    public static runInTerminal(command: string, cwd?: string, addNewLine: boolean = true, terminal: string = ".NET Test Explorer"): void {
         if (this.terminals[terminal] === undefined) {
             this.terminals[terminal] = vscode.window.createTerminal(terminal);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,7 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.refreshTestExplorer", () => {
+        testDirectories.parseTestDirectories();
         dotnetTestExplorer.refreshTestExplorer();
     }));
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,7 +24,7 @@ export class Logger {
         }
     }
 
-    private static defaultOutput = "Test Explorer";
+    private static defaultOutput = ".NET Test Explorer";
 
     private static outputTerminals: { [id: string]: vscode.OutputChannel } = {};
 


### PR DESCRIPTION
This PR is a collection of multiple QOL changes to make test discovery more intuitive:

- Add a hint to set `testProjectPath` when no tests are found. This includes a link to the settings:
![image](https://user-images.githubusercontent.com/8687777/84032938-6736f700-a998-11ea-9479-ec95ac674090.png)
  (Sadly, the markdown does not seem to support code blocks for the setting.)
- Add examples to the `testProjectPath` setting that include globs:
![image](https://user-images.githubusercontent.com/8687777/84033035-8a61a680-a998-11ea-9d0f-56b3a634e12c.png)
- Rerun the glob when pressing "Refresh" (it's nasty when you rename some files, press refresh and the test explorer doesn't update)
- Rename the output log to ".NET Test Explorer" (the name "Test Explorer" is already used by other extensions on my setup, leading to confusion that I'm probably not alone with)

I'd say that this fixes #217.