### PR TITLE
Add support for settings files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Text from the dotnet test output as well as debug info is written to the Output/
 * `dotnet-test-explorer.addProblems`: If true, failed tests will add to problems view. (Default is **true**)
 * `dotnet-test-explorer.autoWatch`: If true, starts dotnet watch test after test discovery is completed. (Default is **false**)
 * `dotnet-test-explorer.testArguments`: Additional arguments that are added to the dotnet test command
+* `dotnet-test-explorer.settingsFile`: Optional path to a settings file for the tests
 * `dotnet-test-explorer.leftClickAction`: What happens when a test in the list is left clicked. (Default is **gotoTest**)
 * `dotnet-test-explorer.runInParallel`: If true, will discover/build and run test in parallel if you have multiple test projects (Default is **false**)
 

--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
           "default": "",
           "description": "Additional arguments that are added to the dotnet test command."
         },
+        "dotnet-test-explorer.settingsFile": {
+          "type": "string",
+          "default": "",
+          "description": "Settings file for tests."
+        },
         "dotnet-test-explorer.leftClickAction": {
           "type": "string",
           "default": "gotoTest",

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -226,7 +226,7 @@ export class TestCommands implements Disposable {
 
         return new Promise((resolve, reject) => {
             const testResultFile = path.join(this.testResultsFolder, trxTestName);
-            let command = `dotnet test${Utility.additionalArgumentsOption} --no-build --logger \"trx;LogFileName=${testResultFile}\"`;
+            let command = `dotnet test${Utility.additionalArgumentsOption} ${Utility.settingsFileOption} --no-build --logger \"trx;LogFileName=${testResultFile}\"`;
 
             if (testName && testName.length) {
                 if (isSingleTest) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -38,6 +38,11 @@ export class Utility {
         return (testArguments && testArguments.length > 0) ? ` ${testArguments}` : "";
     }
 
+    public static get settingsFileOption(): string {
+        const settingsFile = Utility.getConfiguration().get<string>("settingsFile");
+        return (settingsFile && settingsFile.length > 0) ? ` --settings:${settingsFile}` : "";
+    }
+
     public static getConfiguration(): vscode.WorkspaceConfiguration {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
     }


### PR DESCRIPTION
Hi - my dotnet project requires a test settings file. I struggled with the testArguments setting, so figured I'd add direct support for the settings parameter.