### PR TITLE
auto attach debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn.*
 [Bb]in/
 [Oo]bj/
 lcov.info
+.vscode-test
+*.vsix

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "dotnet-test-explorer",
   "displayName": ".NET Core Test Explorer",
   "description": "Test Explorer for .NET Core (MSTest, xUnit, NUnit)",
-  "version": "0.7.4",
+  "version": "0.7.4-ak1",
   "publisher": "formulahendry",
   "license": "MIT",
   "icon": "testexplorer_dark.png",
   "engines": {
-    "vscode": "^1.25.1"
+    "vscode": "^1.45.1"
   },
   "categories": [
     "Programming Languages"
@@ -252,6 +252,16 @@
           "type": "string",
           "default": "",
           "description": "Additional arguments that are added to the dotnet test command."
+        },
+        "dotnet-test-explorer.testhost.started.pattern": {
+          "type": "string",
+          "default": "Host debugging is enabled",
+          "description": "Pattern in stdout of testhost that triggers attachment of debugger"
+        },
+        "dotnet-test-explorer.testhost.processId.pattern": {
+          "type": "string",
+          "default": "Process Id: (\\d+),",
+          "description": "Pattern in stdout of testhost that matches its process id"
         },
         "dotnet-test-explorer.leftClickAction": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, will discover/build and run test in parallel if you have multiple test projects"
+        },
+        "dotnet-test-explorer.clearTerminalBeforeTestRun": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, clears the output panel before running/debugging test"
         }
       }
     },

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,7 +1,4 @@
 import * as vscode from "vscode";
-import { Logger } from "./logger";
-import { TestCommands } from "./testCommands";
-import { ITestResult, TestResult } from "./testResult";
 import { Utility } from "./utility";
 
 export interface IDebugRunnerInfo {
@@ -28,7 +25,7 @@ export class Debug {
 
         if (debugRunnerInfo.processId.length <= 0) {
             const match = this.processIdRegexp.exec(data);
-            
+
             if (match && match[1]) {
                 debugRunnerInfo.processId = match[1];
             }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -20,10 +20,6 @@ export class Executor {
     }
 
     public static exec(command: string, callback, cwd?: string, addToProcessList?: boolean) {
-        if (Utility.clearTerminalBeforeTestRun){
-            Logger.Clear();
-        }
-
         // DOTNET_CLI_UI_LANGUAGE does not seem to be respected when passing it as a parameter to the exec
         // function so we set the variable here instead
         process.env.DOTNET_CLI_UI_LANGUAGE = "en";
@@ -37,7 +33,7 @@ export class Executor {
 
             this.processes.push(childProcess);
             childProcess.stdout.on("data", (buf) => {
-                Logger.Log(buf);
+                Logger.LogRaw(buf);
             });
 
             childProcess.on("close", (code: number) => {
@@ -54,9 +50,6 @@ export class Executor {
     }
 
     public static debug(command: string, callback, cwd?: string, addToProcessList?: boolean) {
-        if (Utility.clearTerminalBeforeTestRun){
-            Logger.Clear();
-        }
         // DOTNET_CLI_UI_LANGUAGE does not seem to be respected when passing it as a parameter to the exec
         // function so we set the variable here instead
         process.env.DOTNET_CLI_UI_LANGUAGE = "en";
@@ -85,7 +78,7 @@ export class Executor {
                 }
 
                 const stdout = String(buf);
-                Logger.Log(stdout);
+                Logger.LogRaw(stdout);
 
                 this.debugRunnerInfo = debug.onData(stdout, this.debugRunnerInfo);
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -4,6 +4,7 @@ import { platform } from "os";
 import * as vscode from "vscode";
 import { Debug, IDebugRunnerInfo } from "./debug";
 import { Logger } from "./logger";
+import { Utility } from "./utility";
 
 export class Executor {
 
@@ -19,6 +20,10 @@ export class Executor {
     }
 
     public static exec(command: string, callback, cwd?: string, addToProcessList?: boolean) {
+        if (Utility.clearTerminalBeforeTestRun){
+            Logger.Clear();
+        }
+
         // DOTNET_CLI_UI_LANGUAGE does not seem to be respected when passing it as a parameter to the exec
         // function so we set the variable here instead
         process.env.DOTNET_CLI_UI_LANGUAGE = "en";
@@ -49,6 +54,9 @@ export class Executor {
     }
 
     public static debug(command: string, callback, cwd?: string, addToProcessList?: boolean) {
+        if (Utility.clearTerminalBeforeTestRun){
+            Logger.Clear();
+        }
         // DOTNET_CLI_UI_LANGUAGE does not seem to be respected when passing it as a parameter to the exec
         // function so we set the variable here instead
         process.env.DOTNET_CLI_UI_LANGUAGE = "en";

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -71,11 +71,11 @@ export class Executor {
             this.processes.push(childProcess);
 
             childProcess.stdout.on("data", (buf) => {
-                
+
                 if (this.debugRunnerInfo && this.debugRunnerInfo.isRunning) {
                     return;
                 }
-                
+
                 const stdout = String(buf);
                 Logger.Log(stdout);
 
@@ -87,7 +87,7 @@ export class Executor {
 
                     this.debugRunnerInfo.isRunning = true;
 
-                    vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], this.debugRunnerInfo.config).then( (c) => {
+                    vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], this.debugRunnerInfo.config).then((c) => {
                         // When we attach to the debugger it seems to be stuck before loading the actual assembly that's running in code
                         // This is to try to continue past this invisible break point and into the actual code the user wants to debug
                         setTimeout(() => {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -31,6 +31,9 @@ export class Executor {
             Logger.Log(`Process ${childProcess.pid} started`);
 
             this.processes.push(childProcess);
+            childProcess.stdout.on("data", (buf) => {
+                Logger.Log(buf);
+            });
 
             childProcess.on("close", (code: number) => {
 
@@ -63,24 +66,24 @@ export class Executor {
         if (addToProcessList) {
 
             Logger.Log(`Process ${childProcess.pid} started`);
+            Logger.Log(`Waiting for debugger to attach`);
 
             this.processes.push(childProcess);
 
             childProcess.stdout.on("data", (buf) => {
-
+                
                 if (this.debugRunnerInfo && this.debugRunnerInfo.isRunning) {
                     return;
                 }
-
-                Logger.Log(`Waiting for debugger to attach`);
-
+                
                 const stdout = String(buf);
+                Logger.Log(stdout);
 
                 this.debugRunnerInfo = debug.onData(stdout, this.debugRunnerInfo);
 
                 if (this.debugRunnerInfo.config) {
 
-                    Logger.Log(`Debugger process found, attaching`);
+                    Logger.Log(`Debugger process found (pid: ${this.debugRunnerInfo.processId}), attaching`);
 
                     this.debugRunnerInfo.isRunning = true;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,20 +2,24 @@
 import * as vscode from "vscode";
 
 export class Logger {
-    public static Log(message: string, output: string = this.defaultOutput): void {
+    public static LogRaw(message: string, output: string = this.defaultOutput): void {
         if (this.outputTerminals[output] === undefined ) {
             this.outputTerminals[output] = vscode.window.createOutputChannel(output);
         }
 
-        this.outputTerminals[output].appendLine(message);
+        this.outputTerminals[output].appendLine(message.trim());
+    }
+
+    public static Log(message: string): void {
+        Logger.LogRaw(`[INFO] ${message}`);
     }
 
     public static LogError(message: string, error: any): void {
-        Logger.Log(`[ERROR] ${message} - ${Logger.formatError(error)}`);
+        Logger.LogRaw(`[ERROR] ${message} - ${Logger.formatError(error)}`);
     }
 
     public static LogWarning(message: string): void {
-        Logger.Log(`[WARNING] ${message}`);
+        Logger.LogRaw(`[WARNING] ${message}`);
     }
 
     public static Clear(output: string = this.defaultOutput): void {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,6 +18,10 @@ export class Logger {
         Logger.Log(`[WARNING] ${message}`);
     }
 
+    public static Clear(output: string = this.defaultOutput): void {
+        this.outputTerminals[output].clear();
+    }
+
     public static Show(): void {
         if (this.outputTerminals && this.outputTerminals[this.defaultOutput]) {
             this.outputTerminals[this.defaultOutput].show();

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -262,6 +262,10 @@ export class TestCommands implements Disposable {
 
             this.runBuildCommandForSpecificDirectory(testDirectoryPath)
                 .then(() => {
+                    if (Utility.clearTerminalBeforeTestRun){
+                        Logger.Clear();
+                        Logger.Show();
+                    }
                     Logger.Log(`Executing ${command} in ${testDirectoryPath}`);
 
                     if (!debug) {

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -272,8 +272,6 @@ export class TestCommands implements Disposable {
                                 reject(new Error("UserAborted"));
                             }
 
-                            Logger.Log(stdout, "Test Explorer (Test runner output)");
-
                             resolve();
                         }, testDirectoryPath, true);
                     } else {
@@ -283,8 +281,6 @@ export class TestCommands implements Disposable {
                                 Logger.Log("User has probably cancelled test run");
                                 reject(new Error("UserAborted"));
                             }
-
-                            Logger.Log(stdout, "Test Explorer (Test runner output)");
 
                             resolve();
                         }, testDirectoryPath, true);

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -7,6 +7,7 @@ export class Utility {
 
     public static skipBuild: boolean;
     public static runInParallel: boolean;
+    public static clearTerminalBeforeTestRun: boolean;
 
     public static get codeLensEnabled(): boolean {
         return Utility.showCodeLens;
@@ -84,6 +85,7 @@ export class Utility {
         Utility.autoExpandTree = configuration.get<boolean>("autoExpandTree", false);
         Utility.skipBuild = Utility.additionalArgumentsOption.indexOf("--no-build") > -1;
         Utility.runInParallel = configuration.get<boolean>("runInParallel", false);
+        Utility.clearTerminalBeforeTestRun = configuration.get<boolean>("clearTerminalBeforeTestRun", false);
     }
 
     /**

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -38,6 +38,16 @@ export class Utility {
         return (testArguments && testArguments.length > 0) ? ` ${testArguments}` : "";
     }
 
+    public static get testhostStartedPattern(): string {
+        const pattern = Utility.getConfiguration().get<string>("testhost.started.pattern");
+        return (pattern && pattern.length > 0) ? pattern : "Host debugging is enabled";
+    }
+
+    public static get testhostProcessIdPattern(): string {
+        const pattern = Utility.getConfiguration().get<string>("testhost.processId.pattern");
+        return (pattern && pattern.length > 0) ? pattern : "Process Id: (\d+),";
+    }
+
     public static getConfiguration(): vscode.WorkspaceConfiguration {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
     }

--- a/test/debug.test.ts
+++ b/test/debug.test.ts
@@ -10,13 +10,13 @@ suite("Debug tests", () => {
         assert.equal(results.isSettingUp, true);
     });
 
-    test("Detects that debug is ready for attach har started", () => {
+    test("Detects that debug is ready for attach has started", () => {
         const debug = new Debug();
 
         let results = debug.onData("data");
         results = debug.onData(`
             This is output from vstest
-            Waiting for debugger attach...
+            Host debugging is enabled
             Tra la lalala la
         `, results);
 
@@ -44,7 +44,7 @@ suite("Debug tests", () => {
 
         results = debug.onData(`
             This is output from vstest
-            Waiting for debugger attach...
+            Host debugging is enabled
             Tra la lalala la
         `, results);
 


### PR DESCRIPTION
I made the pattern configurable such that the testhost process is detected automatically again.

I think the following issues/pull requests are addressed:
Fixes #247 #273 

Also, I removed the Test Explorer (Test runner output) terminal. All output is merged inside the .net test explorer terminal.

And I added an option to clear the output terminal before test execution.