### PR TITLE
Fix display doubled tests on workspaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -97,13 +97,14 @@
                 "${workspaceRoot}/test/fsxunittests",
                 "${workspaceRoot}/test/mstest",
                 "${workspaceRoot}/test/.vscode",
+                "${workspaceRoot}/test",
                 "--extensionDevelopmentPath=${workspaceRoot}", 
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
             "preLaunchTask": "npm"
-        },          
+        },
         {
             "name": "Launch Tests",
             "type": "extensionHost",

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -82,9 +82,16 @@ export class TestCommands implements Disposable {
         runSeqOrAsync();
     }
 
-    public async discoverTestsInFolder(dir: string): Promise<IDiscoverTestsResult> {
-        const testsForDir: IDiscoverTestsResult = await discoverTests(dir, Utility.additionalArgumentsOption);
-        this.testDirectories.addTestsForDirectory(testsForDir.testNames.map((tn) => ({ dir, name: tn })));
+    public async discoverTestsInFolder(
+        dir: string
+    ): Promise<IDiscoverTestsResult> {
+        const testsForDir: IDiscoverTestsResult = await discoverTests(
+            dir,
+            Utility.additionalArgumentsOption
+        );
+        const tests = testsForDir.testNames.map((tn) => ({ dir, name: tn }));
+        testsForDir.testNames = this.testDirectories.addTestsForDirectory(tests);
+
         return testsForDir;
     }
 

--- a/src/testDirectories.ts
+++ b/src/testDirectories.ts
@@ -36,8 +36,21 @@ export class TestDirectories {
         this.directories = evaluateTestDirectories(matchingDirs);
     }
 
-    public addTestsForDirectory(testsForDirectory) {
-        this.testsForDirectory = this.testsForDirectory.concat(testsForDirectory);
+    public addTestsForDirectory(testsForDirectory): string[] {
+        let tests = [];
+        for (let i = 0; i < testsForDirectory.length; i++) {
+            const exists =
+                this.testsForDirectory.find(
+                    (p) => p.name == testsForDirectory[i].name
+                ) !== undefined;
+            if (!exists) {
+                tests.push(testsForDirectory[i].name)
+                this.testsForDirectory.push(testsForDirectory[i]);
+            } else {
+                Logger.LogWarning(`Test already exist ${testsForDirectory[i].name}`);
+            }
+        }
+        return tests;
     }
 
     public clearTestsForDirectory() {

--- a/test/test.sln
+++ b/test/test.sln
@@ -1,0 +1,90 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XunitTests", "xunittests\XunitTests.csproj", "{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NunitTests5", "nunitNet5\NunitTests.csproj", "{BE718314-C8F6-4137-BF8C-87446B409BB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NunitTests", "nunit\NunitTests.csproj", "{D450231D-6AEC-4382-A57A-4302945064AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSTestTests", "mstest\MSTestTests.csproj", "{4C81F995-488D-4C6F-A74E-E0D60AF1040C}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpTests", "fsxunittests\FSharpTests.fsproj", "{542F16FF-EEFB-4E06-8131-9086AE89C560}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Debug|x86.Build.0 = Debug|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Release|x64.Build.0 = Release|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F20AE29-8CE2-4A54-B5FE-6FAA033357F4}.Release|x86.Build.0 = Release|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Debug|x64.Build.0 = Debug|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Debug|x86.Build.0 = Debug|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Release|x64.ActiveCfg = Release|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Release|x64.Build.0 = Release|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Release|x86.ActiveCfg = Release|Any CPU
+		{BE718314-C8F6-4137-BF8C-87446B409BB2}.Release|x86.Build.0 = Release|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Release|x64.Build.0 = Release|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{D450231D-6AEC-4382-A57A-4302945064AA}.Release|x86.Build.0 = Release|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Debug|x64.Build.0 = Debug|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Debug|x86.Build.0 = Debug|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Release|x64.ActiveCfg = Release|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Release|x64.Build.0 = Release|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Release|x86.ActiveCfg = Release|Any CPU
+		{4C81F995-488D-4C6F-A74E-E0D60AF1040C}.Release|x86.Build.0 = Release|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Debug|x64.Build.0 = Debug|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Debug|x86.Build.0 = Debug|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Release|Any CPU.Build.0 = Release|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Release|x64.ActiveCfg = Release|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Release|x64.Build.0 = Release|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Release|x86.ActiveCfg = Release|Any CPU
+		{542F16FF-EEFB-4E06-8131-9086AE89C560}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
When using a workspace with the structure below tests are doubled:
FolderMaster is the root folder that contains Folder1, Folder2 and Folder3

workspace
- folder1
- folder2
- folder3
- FolderMaster
----| Folder1
----| Folder2
----| Folder3

Same situation if you use a .sln