### PR TITLE
Merge log panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn.*
 [Bb]in/
 [Oo]bj/
 lcov.info
+.vscode-test
+*.vsix

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "icon": "testexplorer_dark.png",
   "engines": {
-    "vscode": "^1.25.1"
+    "vscode": "^1.45.1"
   },
   "categories": [
     "Programming Languages"
@@ -267,6 +267,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, will discover/build and run test in parallel if you have multiple test projects"
+        },
+        "dotnet-test-explorer.clearTerminalBeforeTestRun": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, clears the output panel before running/debugging test"
         }
       }
     },

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -4,6 +4,7 @@ import { platform } from "os";
 import * as vscode from "vscode";
 import { Debug, IDebugRunnerInfo } from "./debug";
 import { Logger } from "./logger";
+import { Utility } from "./utility";
 
 export class Executor {
 
@@ -31,6 +32,9 @@ export class Executor {
             Logger.Log(`Process ${childProcess.pid} started`);
 
             this.processes.push(childProcess);
+            childProcess.stdout.on("data", (buf) => {
+                Logger.LogRaw(buf);
+            });
 
             childProcess.on("close", (code: number) => {
 
@@ -63,6 +67,7 @@ export class Executor {
         if (addToProcessList) {
 
             Logger.Log(`Process ${childProcess.pid} started`);
+            Logger.Log(`Waiting for debugger to attach`);
 
             this.processes.push(childProcess);
 
@@ -72,15 +77,14 @@ export class Executor {
                     return;
                 }
 
-                Logger.Log(`Waiting for debugger to attach`);
-
                 const stdout = String(buf);
+                Logger.LogRaw(stdout);
 
                 this.debugRunnerInfo = debug.onData(stdout, this.debugRunnerInfo);
 
                 if (this.debugRunnerInfo.config) {
 
-                    Logger.Log(`Debugger process found, attaching`);
+                    Logger.Log(`Debugger process found (pid: ${this.debugRunnerInfo.processId}), attaching`);
 
                     this.debugRunnerInfo.isRunning = true;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,20 +2,28 @@
 import * as vscode from "vscode";
 
 export class Logger {
-    public static Log(message: string, output: string = this.defaultOutput): void {
+    public static LogRaw(message: string, output: string = this.defaultOutput): void {
         if (this.outputTerminals[output] === undefined ) {
             this.outputTerminals[output] = vscode.window.createOutputChannel(output);
         }
 
-        this.outputTerminals[output].appendLine(message);
+        this.outputTerminals[output].appendLine(message.trim());
+    }
+
+    public static Log(message: string): void {
+        Logger.LogRaw(`[INFO] ${message}`);
     }
 
     public static LogError(message: string, error: any): void {
-        Logger.Log(`[ERROR] ${message} - ${Logger.formatError(error)}`);
+        Logger.LogRaw(`[ERROR] ${message} - ${Logger.formatError(error)}`);
     }
 
     public static LogWarning(message: string): void {
-        Logger.Log(`[WARNING] ${message}`);
+        Logger.LogRaw(`[WARNING] ${message}`);
+    }
+
+    public static Clear(output: string = this.defaultOutput): void {
+        this.outputTerminals[output].clear();
     }
 
     public static Show(): void {

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -262,6 +262,10 @@ export class TestCommands implements Disposable {
 
             this.runBuildCommandForSpecificDirectory(testDirectoryPath)
                 .then(() => {
+                    if (Utility.clearTerminalBeforeTestRun){
+                        Logger.Clear();
+                        Logger.Show();
+                    }
                     Logger.Log(`Executing ${command} in ${testDirectoryPath}`);
 
                     if (!debug) {
@@ -272,8 +276,6 @@ export class TestCommands implements Disposable {
                                 reject(new Error("UserAborted"));
                             }
 
-                            Logger.Log(stdout, "Test Explorer (Test runner output)");
-
                             resolve();
                         }, testDirectoryPath, true);
                     } else {
@@ -283,8 +285,6 @@ export class TestCommands implements Disposable {
                                 Logger.Log("User has probably cancelled test run");
                                 reject(new Error("UserAborted"));
                             }
-
-                            Logger.Log(stdout, "Test Explorer (Test runner output)");
 
                             resolve();
                         }, testDirectoryPath, true);

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -7,6 +7,7 @@ export class Utility {
 
     public static skipBuild: boolean;
     public static runInParallel: boolean;
+    public static clearTerminalBeforeTestRun: boolean;
 
     public static get codeLensEnabled(): boolean {
         return Utility.showCodeLens;
@@ -74,6 +75,7 @@ export class Utility {
         Utility.autoExpandTree = configuration.get<boolean>("autoExpandTree", false);
         Utility.skipBuild = Utility.additionalArgumentsOption.indexOf("--no-build") > -1;
         Utility.runInParallel = configuration.get<boolean>("runInParallel", false);
+        Utility.clearTerminalBeforeTestRun = configuration.get<boolean>("clearTerminalBeforeTestRun", false);
     }
 
     /**


### PR DESCRIPTION
This PR is a follow up on #293 . Here only the changes concerning log output are contained.

The features are:
* live log during changes of ``` dotnet test ``` stdout
* merged output inside the single ".NET Test Explorer" output panel.
* the extension logs are prefixed by [info],... tag, while the stdout of ``` dotnet test ``` is plain
* option to clear the panel before test execution.