### PR TITLE
make attachment to debugger configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn.*
 [Bb]in/
 [Oo]bj/
 lcov.info
+.vscode-test
+*.vsix

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "icon": "testexplorer_dark.png",
   "engines": {
-    "vscode": "^1.25.1"
+    "vscode": "^1.45.1"
   },
   "categories": [
     "Programming Languages"
@@ -252,6 +252,16 @@
           "type": "string",
           "default": "",
           "description": "Additional arguments that are added to the dotnet test command."
+        },
+        "dotnet-test-explorer.testhost.started.pattern": {
+          "type": "string",
+          "default": "Host debugging is enabled",
+          "description": "Pattern in stdout of testhost that triggers attachment of debugger"
+        },
+        "dotnet-test-explorer.testhost.processId.pattern": {
+          "type": "string",
+          "default": "Process Id: (\\d+),",
+          "description": "Pattern in stdout of testhost that matches its process id"
         },
         "dotnet-test-explorer.leftClickAction": {
           "type": "string",

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,6 +1,4 @@
 import * as vscode from "vscode";
-import { TestCommands } from "./testCommands";
-import { ITestResult, TestResult } from "./testResult";
 import { Utility } from "./utility";
 
 export interface IDebugRunnerInfo {
@@ -12,7 +10,8 @@ export interface IDebugRunnerInfo {
 }
 
 export class Debug {
-    private processIdRegexp = /Process Id: (.*),/gm;
+    private processIdRegexp = new RegExp(Utility.testhostProcessIdPattern, 'mi');
+    private debuggingEnabledRegexp = new RegExp(Utility.testhostStartedPattern, 'mi');
 
     public onData(data: string, debugRunnerInfo?: IDebugRunnerInfo): IDebugRunnerInfo  {
 
@@ -20,8 +19,8 @@ export class Debug {
             debugRunnerInfo = {isRunning: false, isSettingUp: true, waitingForAttach: false, processId: ""};
         }
 
-        if (!debugRunnerInfo.waitingForAttach) {
-            debugRunnerInfo.waitingForAttach = data.indexOf("Waiting for debugger attach...") > -1;
+        if (!debugRunnerInfo.waitingForAttach && this.debuggingEnabledRegexp.test(data)) {
+            debugRunnerInfo.waitingForAttach = true;
         }
 
         if (debugRunnerInfo.processId.length <= 0) {

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -80,7 +80,7 @@ export class Executor {
 
                 if (this.debugRunnerInfo.config) {
 
-                    Logger.Log(`Debugger process found, attaching`);
+                    Logger.Log(`Debugger process found (pid: ${this.debugRunnerInfo.processId}), attaching`);
 
                     this.debugRunnerInfo.isRunning = true;
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -38,6 +38,16 @@ export class Utility {
         return (testArguments && testArguments.length > 0) ? ` ${testArguments}` : "";
     }
 
+    public static get testhostStartedPattern(): string {
+        const pattern = Utility.getConfiguration().get<string>("testhost.started.pattern");
+        return (pattern && pattern.length > 0) ? pattern : "Host debugging is enabled";
+    }
+
+    public static get testhostProcessIdPattern(): string {
+        const pattern = Utility.getConfiguration().get<string>("testhost.processId.pattern");
+        return (pattern && pattern.length > 0) ? pattern : "Process Id: (\d+),";
+    }
+
     public static getConfiguration(): vscode.WorkspaceConfiguration {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
     }

--- a/test/debug.test.ts
+++ b/test/debug.test.ts
@@ -10,13 +10,13 @@ suite("Debug tests", () => {
         assert.equal(results.isSettingUp, true);
     });
 
-    test("Detects that debug is ready for attach har started", () => {
+    test("Detects that debug is ready for attach has started", () => {
         const debug = new Debug();
 
         let results = debug.onData("data");
         results = debug.onData(`
             This is output from vstest
-            Waiting for debugger attach...
+            Host debugging is enabled
             Tra la lalala la
         `, results);
 
@@ -44,7 +44,7 @@ suite("Debug tests", () => {
 
         results = debug.onData(`
             This is output from vstest
-            Waiting for debugger attach...
+            Host debugging is enabled
             Tra la lalala la
         `, results);
 


### PR DESCRIPTION
This PR is a follow up on #293 . It contains those changes to fix attachment of debugger.

The features are:
* add two configuration values
* one configures the pattern from ``` dotnet test ``` that states that it is waiting for a debugger
* the other configures the pattern to get the processid for testhost.exe
