### PR TITLE
A few changes that make discovery and reporting of F# tests more complete

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,10 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerCodeLensProvider(
         { language: "csharp", scheme: "file" },
         codeLensProvider));
+    context.subscriptions.push(vscode.languages.registerCodeLensProvider(
+        {language: "fsharp", scheme: "file" },
+        codeLensProvider
+    ));
 
     context.subscriptions.push(vscode.commands.registerCommand("dotnet-test-explorer.showLog", () => {
         Logger.Show();

--- a/src/gotoTest.ts
+++ b/src/gotoTest.ts
@@ -71,6 +71,6 @@ export class GotoTest {
     }
 
     private isSymbolATestCandidate(s: vscode.SymbolInformation): boolean {
-        return s.location.uri.toString().endsWith(".fs") ? s.kind === vscode.SymbolKind.Variable : s.kind === vscode.SymbolKind.Method;
+        return s.location.uri.toString().endsWith(".fs") ? (s.kind === vscode.SymbolKind.Variable || s.kind === vscode.SymbolKind.Field) : s.kind === vscode.SymbolKind.Method;
     }
 }

--- a/src/gotoTest.ts
+++ b/src/gotoTest.ts
@@ -69,8 +69,8 @@ export class GotoTest {
 
         return testName;
     }
-
+    private fsharpSymbolKinds = [vscode.SymbolKind.Variable, vscode.SymbolKind.Field, vscode.SymbolKind.Method];
     private isSymbolATestCandidate(s: vscode.SymbolInformation): boolean {
-        return s.location.uri.toString().endsWith(".fs") ? (s.kind === vscode.SymbolKind.Variable || s.kind === vscode.SymbolKind.Field) : s.kind === vscode.SymbolKind.Method;
+        return s.location.uri.toString().endsWith(".fs") ? this.fsharpSymbolKinds.includes(s.kind) : s.kind === vscode.SymbolKind.Method;
     }
 }

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -9,7 +9,7 @@ import { Utility } from "./utility";
 export class TestStatusCodeLensProvider implements CodeLensProvider {
     private disposables: Disposable[] = [];
     private onDidChangeCodeLensesEmitter = new EventEmitter<void>();
-
+    private fsharpSymbolKinds = [SymbolKind.Field, SymbolKind.Variable, SymbolKind.Method];
     // Store everything in a map so we can remember old tests results for the
     // scenario where a single test is ran. If the test no longer exists in
     // code it will never be mapped to the symbol, so no harm (though there is
@@ -38,10 +38,8 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
 
         const symbolFilter =
             document.languageId === 'fsharp'
-            ? ((x: ITestSymbol) =>
-                x.documentSymbol.kind === SymbolKind.Field || x.documentSymbol.kind === SymbolKind.Variable)
-            : ((x: ITestSymbol) =>
-                x.documentSymbol.kind === SymbolKind.Method)
+            ? ((x: ITestSymbol) => this.fsharpSymbolKinds.includes(x.documentSymbol.kind))
+            : ((x: ITestSymbol) => x.documentSymbol.kind === SymbolKind.Method)
 
         const results = this.testResults;
 

--- a/src/testStatusCodeLensProvider.ts
+++ b/src/testStatusCodeLensProvider.ts
@@ -36,12 +36,19 @@ export class TestStatusCodeLensProvider implements CodeLensProvider {
             return [];
         }
 
+        const symbolFilter =
+            document.languageId === 'fsharp'
+            ? ((x: ITestSymbol) =>
+                x.documentSymbol.kind === SymbolKind.Field || x.documentSymbol.kind === SymbolKind.Variable)
+            : ((x: ITestSymbol) =>
+                x.documentSymbol.kind === SymbolKind.Method)
+
         const results = this.testResults;
 
         return Symbols.getSymbols(document.uri, true)
         .then((symbols: ITestSymbol[]) => {
             const mapped: CodeLens[] = [];
-            for (const symbol of symbols.filter((x) => x.documentSymbol.kind === SymbolKind.Method)) {
+            for (const symbol of symbols.filter((x) => symbolFilter(x))) {
                 for (const result of results.values()) {
                     if (result.matches(symbol.parentName, symbol.documentSymbol.name)) {
                         const state = TestStatusCodeLens.parseOutcome(result.outcome);


### PR DESCRIPTION
These changes, along with a companion MR I'll be sending to F# AutoComplete here in a moment, make F# support in this extension much better.

One of the core problems regarding F# support here was the lack of symbol finding. This was a bug in FSAC around how it did detections for symbols.  Once I fixed that, I found that this project had trouble finding other kinds of F# tests, because FSAC would report those tests as Fields or Variables (which they are from an F# perspective, as `methods` are something that Classes have, not naked functions in Modules.  Once I expanded the filters for determining if a symbol might be a test for F#, and then for mapping test results to symbols, this extension worked great!