### PR TITLE
Respect the dismiss option for failed build

### DIFF
--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -212,7 +212,9 @@ export class TestCommands implements Disposable {
                     .showErrorMessage("Build failed. Fix your build and try to run the test(s) again", "Re-run test(s)",)
                     .then(selection => {
                         if (selection !== undefined)
+                        {
                             vscode.commands.executeCommand("dotnet-test-explorer.rerunLastCommand");
+                        }
                     });;
 
                 for (const { } of testDirectories) {

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -211,7 +211,8 @@ export class TestCommands implements Disposable {
                     .window
                     .showErrorMessage("Build failed. Fix your build and try to run the test(s) again", "Re-run test(s)",)
                     .then(selection => {
-                        vscode.commands.executeCommand("dotnet-test-explorer.rerunLastCommand");
+                        if (selection !== undefined)
+                            vscode.commands.executeCommand("dotnet-test-explorer.rerunLastCommand");
                     });;
 
                 for (const { } of testDirectories) {


### PR DESCRIPTION
When the build fails, the popup would restart the build/test run, even when dismissed. It's a small QoL thing.

When `selection` is `undefined`, it means the window was dismissed (and the tests should not be re-run I think). ([doc](https://code.visualstudio.com/api/references/vscode-api#window.showInformationMessage))

Thank you for creating/maintaining this awesome tool!