### PR TITLE
Support localized strings when parsing test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Prerequisites
 
 * [.NET Core](https://www.microsoft.com/net/core) is installed
-* NUnit and MSTest requires a dotnet [sdk](https://www.microsoft.com/net/download) version of >= 2.2.104 and running dotnet tooling in English (see [#77](https://github.com/formulahendry/vscode-dotnet-test-explorer/issues/77) for details).
+* NUnit and MSTest requires a dotnet [sdk](https://www.microsoft.com/net/download) version of >= 2.2.104.
 
 ## New in 0.7.6
 
@@ -83,8 +83,8 @@ This is because of limitations in the omnisharp extensions. We can only navigate
 ##### Test result is not shown in CodeLens / tree
 Try and change the setting dotnet-test-explorer.pathForResultFile to point to a folder you have access right too. CodeLens functionality also requires the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)) 
 
-##### No tree view or color coded explorer for NUnit / MSTest
-This requires you to run dotnet SDK version 2.2.104 or higher. The extension tries to run the commands with the English cli but if things are not working as expected anyway it may be due to the cli language (see [#77](https://github.com/formulahendry/vscode-dotnet-test-explorer/issues/77) for details).
+##### No tree view or color-coded explorer for NUnit / MSTest
+This requires you to run dotnet SDK version 2.2.104 or higher.
 
 ##### xUnit projects assembly name needs to match the test class namespace
 See [#201](https://github.com/formulahendry/vscode-dotnet-test-explorer/issues/201)

--- a/test/testDiscovery.test.ts
+++ b/test/testDiscovery.test.ts
@@ -240,8 +240,8 @@ function buildDotnetTestOutput(testNames: string[], testAssemblyFilePath: string
 Build started, please wait...
 Build completed.
 
-Test run for ${testAssemblyFilePath}(.NETCoreApp,Version=v2.0)
-Microsoft (R) Test Execution Command Line Tool Version 15.6.0-preview-20180109-01
+Test run for ${testAssemblyFilePath} (.NETCoreApp,Version=v5.0)
+Microsoft (R) Test Execution Command Line Tool Version 16.11.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
 The following Tests are available:
@@ -251,8 +251,8 @@ The following Tests are available:
 La build a démarré. Patientez…
 Fin de la build.
 
-Série de tests pour ${testAssemblyFilePath}(.NETCoreApp,Version=v2.1)
-Outil en ligne de commande d'exécution de tests Microsoft (R), version 15.7.0
+Série de tests pour ${testAssemblyFilePath} (.NETCoreApp,Version=v5.0)
+Outil en ligne de commande d'exécution de tests Microsoft (R), version 16.11.0
 Copyright (c) Microsoft Corporation. Tous droits réservés.
 
 Les tests suivants sont disponibles :
@@ -267,7 +267,7 @@ function getDotnetTestOutputWithoutTestAssemblyPath() {
 Build started, please wait...
 Build completed.
 
-Microsoft (R) Test Execution Command Line Tool Version 15.6.0-preview-20180109-01
+Microsoft (R) Test Execution Command Line Tool Version 16.11.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
 The following Tests are available:
@@ -284,8 +284,8 @@ function buildDotnetTestSolutionOutput(testNames: string[], testAssemblyFilePath
         output += String.raw`
 Build completed.
 
-Test run for ${testAssemblyFilePath}(.NETCoreApp,Version=v2.0)
-Microsoft (R) Test Execution Command Line Tool Version 15.6.0-preview-20180109-01
+Test run for ${testAssemblyFilePath} (.NETCoreApp,Version=v5.0)
+Microsoft (R) Test Execution Command Line Tool Version 16.11.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
 
 The following Tests are available:


### PR DESCRIPTION
Fixes #315.

As suggested at https://github.com/formulahendry/vscode-dotnet-test-explorer/issues/315#issuecomment-910747930, this hardcodes all localized format strings for the "Test run for" output line so that the parsing works for any language. It also removes the references to original issue #77 from the README.