### PR TITLE
adding ability to have separate discovery and execution test arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
         "dotnet-test-explorer.testArguments": {
           "type": "string",
           "default": "",
-          "description": "Additional arguments that are added to the dotnet test command."
+          "description": "Additional arguments that are added to the dotnet test command druing discovery and execution."
         },
         "dotnet-test-explorer.testArgumentsDiscovery": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -253,6 +253,16 @@
           "default": "",
           "description": "Additional arguments that are added to the dotnet test command."
         },
+        "dotnet-test-explorer.testArgumentsDiscovery": {
+            "type": "string",
+            "default": "",
+            "description": "Additional arguments that are added to the dotnet test command during discovery of tests."
+        },
+        "dotnet-test-explorer.testArgumentsExecute": {
+            "type": "string",
+            "default": "",
+            "description": "Additional arguments that are added to the dotnet test command during execution of tests."
+        },
         "dotnet-test-explorer.leftClickAction": {
           "type": "string",
           "default": "gotoTest",

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -83,7 +83,7 @@ export class TestCommands implements Disposable {
     }
 
     public async discoverTestsInFolder(dir: string): Promise<IDiscoverTestsResult> {
-        const testsForDir: IDiscoverTestsResult = await discoverTests(dir, Utility.additionalArgumentsOption);
+        const testsForDir: IDiscoverTestsResult = await discoverTests(dir, Utility.additionalDiscoveryArgumentsOption);
         this.testDirectories.addTestsForDirectory(testsForDir.testNames.map((tn) => ({ dir, name: tn })));
         return testsForDir;
     }
@@ -253,7 +253,7 @@ export class TestCommands implements Disposable {
 
         return new Promise((resolve, reject) => {
             const testResultFile = path.join(this.testResultsFolder, trxTestName);
-            let command = `dotnet test${Utility.additionalArgumentsOption} --no-build --logger \"trx;LogFileName=${testResultFile}\"`;
+            let command = `dotnet test${Utility.additionalExecutionArgumentsOption} --no-build --logger \"trx;LogFileName=${testResultFile}\"`;
 
             if (testName && testName.length) {
                 if (isSingleTest) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -42,6 +42,22 @@ export class Utility {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
     }
 
+    public static get additionalDiscoveryArgumentsOption() {
+        const testArguments = Utility.getConfiguration().get<string>("testArguments");
+        const discoveryArguments = Utility.getConfiguration().get<string>("testArgumentsDiscovery");
+        let args = (testArguments && testArguments.length > 0) ? ` ${testArguments}` : "";
+        args = (discoveryArguments && discoveryArguments.length > 0) ? ` ${discoveryArguments}` : "";
+        return args
+    }
+
+    public static get additionalExecutionArgumentsOption() {
+        const testArguments = Utility.getConfiguration().get<string>("testArguments");
+        const execArguments = Utility.getConfiguration().get<string>("testArgumentsExecution");
+        let args = (testArguments && testArguments.length > 0) ? ` ${testArguments}` : "";
+        args = (execArguments && execArguments.length > 0) ? ` ${execArguments}` : "";
+        return args
+    }
+
     public static getFqnTestName(testName: string): string {
 
         // Converts a test name to a fqn version

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -41,7 +41,7 @@ export class Watch {
         const trxPath = path.join(this.testCommands.testResultFolder, `autoWatch${index}.trx`);
 
         AppInsightsClient.sendEvent("runWatchCommand");
-        const command = `dotnet watch test ${Utility.additionalArgumentsOption}`
+        const command = `dotnet watch test ${Utility.additionalExecutionArgumentsOption}`
             + ` --verbosity:quiet` // be less verbose to avoid false positives when parsing output
             + ` --logger "trx;LogFileName=${trxPath}"`;
 

--- a/test/mstest/.vscode/settings.json
+++ b/test/mstest/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet-test-explorer.testProjectPath": "*Tests.csproj",
+}

--- a/test/nunit/.vscode/settings.json
+++ b/test/nunit/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "dotnet-test-explorer.testProjectPath": "*Tests.csproj",
+    "dotnet-test-explorer.testArgumentsDiscovery": "-- NUnit.DisplayName=FullName"
+}

--- a/test/nunit/NunitTests.csproj
+++ b/test/nunit/NunitTests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="nunit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.13.2"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0"/>
   </ItemGroup>
 
 </Project>

--- a/test/xunittests/.vscode/settings.json
+++ b/test/xunittests/.vscode/settings.json
@@ -2,5 +2,6 @@
     "dotnet-test-explorer.useTreeView": true,
     "dotnet-test-explorer.testArguments": "/p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=../../lcov.info",
     "dotnet-test-explorer.autoWatch": false,
-    "dotnet-test-explorer.runInParallel": true
+    "dotnet-test-explorer.runInParallel": true,
+    "dotnet-test-explorer.testProjectPath": "*Tests.csproj"
 }


### PR DESCRIPTION
This can help alleviate issues between test discovery and execution that might require different arguments as with the `-- NUnit.DisplayName=FullName` argument for NUnit.