### PR TITLE
Stop dotnet watch processes on windows.

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -118,13 +118,22 @@ export class Executor {
     }
 
     public static stop() {
-        this.processes.forEach((p) => {
+        const killPromises = this.processes.map((p) => {
             Logger.Log(`Stop processes requested - ${p.pid} stopped`);
-            p.kill("SIGKILL");
+            return new Promise(resolve => {
+                if (this.isWindows) {
+                    exec(`taskkill /pid ${p.pid} /T /F`).on('close',() => resolve(null));
+                } else {
+                    p.kill("SIGKILL");
+                    resolve(null);
+                }
+            });
         });
 
         this.processes = [];
         this.debugRunnerInfo = null;
+
+        return Promise.all(killPromises);
     }
 
     private static debugRunnerInfo: IDebugRunnerInfo;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,4 +122,5 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+    return Executor.stop();
 }


### PR DESCRIPTION
Fixes #347 and a similar issue where closing vscode leaves the dotnet watch processes around (also only on windows)