### PR TITLE
Support solution filters

### DIFF
--- a/src/testDirectories.ts
+++ b/src/testDirectories.ts
@@ -80,8 +80,8 @@ function evaluateTestDirectories(testDirectories: string[]): string[] {
                 testProjectFullPath = path.dirname(testProjectFullPath);
             }
 
-            if (glob.sync(`${testProjectFullPath}/+(*.csproj|*.sln|*.fsproj)`).length < 1) {
-                Logger.LogWarning(`Skipping path ${testProjectFullPath} since it does not contain something we can build (.sln, .csproj, .fsproj)`);
+            if (glob.sync(`${testProjectFullPath}/+(*.csproj|*.sln|*.slnf|*.fsproj)`).length < 1) {
+                Logger.LogWarning(`Skipping path ${testProjectFullPath} since it does not contain something we can build (.sln, .slnf, .csproj, .fsproj)`);
             } else if (!directoriesSet.has(testProjectFullPath)) {
                 Logger.Log(`Adding directory ${testProjectFullPath}`);
                 directories.push(testProjectFullPath);


### PR DESCRIPTION
Hmm, it seems it is not enough.
By running
```bash
dotnet test -t Tests/Tests.slnf
```
I get a lot of stuff. But if I run `dotnet test` just in folder as extension does,
```bash
dotnet test -t Tests/
MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.
```