### PR TITLE
Added support for custom build options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ the glob pattern "+(testProjectOne|testProjectTwo)" or "**/*Tests.csproj" should
 
 Additional arguments that are added to the dotnet test command. These can for instance be used to collect code coverage data (`"/p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=../../lcov.info"`) or pass test settings (`"--settings:./myfilename.runSettings"`)
 
+`dotnet-test-explorer.buildArguments`
+
+Additional arguments that are added to the `dotnet build` command. These can for instance be used to change the configuration of your build (e.g. `--configuration Release`).
+
 
 ## Stopping the current test runner(s)
 

--- a/package.json
+++ b/package.json
@@ -253,6 +253,11 @@
           "default": "",
           "description": "Additional arguments that are added to the dotnet test command."
         },
+        "dotnet-test-explorer.buildArguments": {
+          "type": "string",
+          "default": "",
+          "description": "Additional arguments that are added to the dotnet build command."
+        },
         "dotnet-test-explorer.leftClickAction": {
           "type": "string",
           "default": "gotoTest",

--- a/src/testCommands.ts
+++ b/src/testCommands.ts
@@ -9,7 +9,7 @@ import { Logger } from "./logger";
 import { TestDirectories } from "./testDirectories";
 import { discoverTests, IDiscoverTestsResult } from "./testDiscovery";
 import { TestNode } from "./testNode";
-import { ITestResult, TestResult } from "./testResult";
+import { ITestResult } from "./testResult";
 import { parseResults } from "./testResultsFile";
 import { Utility } from "./utility";
 
@@ -237,7 +237,8 @@ export class TestCommands implements Disposable {
             } else {
                 Logger.Log(`Executing dotnet build in ${testDirectoryPath}`);
 
-                Executor.exec("dotnet build", (err: any, stdout: string) => {
+                let buildCommand = `dotnet build ${Utility.additionalBuildArgumentsOption}`;
+                Executor.exec(buildCommand, (err: any, stdout: string) => {
                     if (err) {
                         reject(new Error("Build command failed"));
                     }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -38,6 +38,11 @@ export class Utility {
         return (testArguments && testArguments.length > 0) ? ` ${testArguments}` : "";
     }
 
+    public static get additionalBuildArgumentsOption(): string {
+        const buildArguments = Utility.getConfiguration().get<string>("buildArguments");
+        return (buildArguments && buildArguments.length > 0) ? ` ${buildArguments}` : "";
+    }
+
     public static getConfiguration(): vscode.WorkspaceConfiguration {
         return vscode.workspace.getConfiguration("dotnet-test-explorer");
     }

--- a/test/xunittests/.vscode/settings.json
+++ b/test/xunittests/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "dotnet-test-explorer.useTreeView": true,
     "dotnet-test-explorer.testArguments": "/p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=../../lcov.info",
+    "dotnet-test-explorer.buildArguments": "--configuration=Release",
     "dotnet-test-explorer.autoWatch": false,
     "dotnet-test-explorer.runInParallel": true
 }


### PR DESCRIPTION
This pull request solves feature request #380 by adding a setting `buildArguments` that is applied when the `dotnet build` command is executed.

- [x] The project compiles.
- [x] The changes have been tested locally.
- [x] The changes have been documented in the README.