### PR TITLE
Typo in statusbar

### DIFF
--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -40,7 +40,7 @@ export class StatusBar {
         const notExecuted = results.filter( (r: TestResult) => r.outcome === "NotExecuted").length;
         const passed = results.filter( (r: TestResult) => r.outcome === "Passed").length;
 
-        this.status.text = `${this.baseStatusText} ($(check) ${passed} | $(x) ${failed}) | $(question) ${notExecuted})`;
+        this.status.text = `${this.baseStatusText} ($(check) ${passed} | $(x) ${failed} | $(question) ${notExecuted})`;
     }
 
     public dispose() {


### PR DESCRIPTION
- Remove misplaced parenthesis


**Before:** 
![image](https://github.com/formulahendry/vscode-dotnet-test-explorer/assets/25635624/31a53e92-9987-459e-bdaf-4e5b118a6a62)
**After:** 
![image](https://github.com/formulahendry/vscode-dotnet-test-explorer/assets/25635624/48374658-4568-490a-bf9f-e954c2f0c692)




